### PR TITLE
Stopgap solution to ID token for outbound requests

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -3,7 +3,7 @@
 # - https://dev.to/ivan/go-build-a-minimal-docker-image-in-just-three-steps-514i
 #
 # Build from repo root dir with:
-# 
+#
 #     $ docker build -t boost/orionadapter -f container/Dockerfile .
 #
 FROM golang:1.13.4-stretch AS builder
@@ -14,7 +14,7 @@ ENV GO111MODULE=on \
 # NOTES.
 # 1. Modules. Without telling the complier explicitly, the build will fail.
 # I wonder why I don't have to set that var when I build on MacOS though...
-# 2. CGO. We're not using any C libs from our Go code so we disable CGO. 
+# 2. CGO. We're not using any C libs from our Go code so we disable CGO.
 # Strangely enough, without doing this explicitly, I get this error when
 # running the container:
 #
@@ -55,12 +55,12 @@ FROM scratch
 COPY --chown=0:0 --from=builder /dist /
 
 # Set up the app to run as a non-root user inside the /data folder
-# User ID 65534 is usually user 'nobody'. 
+# User ID 65534 is usually user 'nobody'.
 # The executor of this image should still specify a user during setup.
 COPY --chown=65534:0 --from=builder /data /data
 USER 65534
 WORKDIR /data
 
 ENTRYPOINT ["/orionadapter"]
-CMD [ "43210" ]
-EXPOSE 43210
+CMD [ "43210", "54321" ]
+EXPOSE 43210 54321

--- a/deployment/egress_filter.yaml
+++ b/deployment/egress_filter.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: orion-egress-filter
+  namespace: default
+spec:
+  workloadSelector:
+    labels:
+      app: httpbin
+  configPatches:
+  # The first patch adds the lua filter to the listener/http connection manager
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        portNumber: 80
+        filterChain:
+          filter:
+            name: "envoy.http_connection_manager"
+            subFilter:
+              name: "envoy.router"
+    patch:
+      operation: INSERT_BEFORE
+      value: # lua filter specification
+        name: envoy.lua
+        config:
+          inlineCode: |
+            function envoy_on_request(request_handle)
+              local headers, body = request_handle:httpCall(
+                    "lua_cluster", {
+                          [":method"] = "GET",
+                          [":path"] = "/",
+                          [":authority"] = "lua_cluster"}, "", 5000)
+              request_handle:headers():add("header", body)
+            end
+  # The second patch adds the cluster that is referenced by the lua code
+  # cds match is omitted as a new cluster is being added
+  - applyTo: CLUSTER
+    # match:
+    #   context: SIDECAR_OUTBOUND
+    patch:
+      operation: ADD
+      value: # cluster specification
+        name: "lua_cluster"
+        type: STRICT_DNS
+        connect_timeout: 5.5s
+        lb_policy: ROUND_ROBIN
+        hosts:
+        - socket_address:
+            protocol: TCP
+            address: "orionadapterservice.istio-system"
+            port_value: 54321

--- a/deployment/egress_routing.yaml
+++ b/deployment/egress_routing.yaml
@@ -1,0 +1,56 @@
+#
+# DO NOT APPLY this config since it ain't working and may cause havoc.
+# See:
+# - https://github.com/orchestracities/boost/issues/24
+#
+
+# apiVersion: networking.istio.io/v1alpha3
+# kind: Gateway
+# metadata:
+#     name: istio-egressgateway
+#     namespace: istio-system
+# spec:
+#   selector:
+#     istio: egressgateway
+#   servers:
+#   - port:
+#       number: 80
+#       name: http
+#       protocol: HTTP
+#     hosts:
+#     - "*"
+# ---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-httpbin
+#  namespace: istio-system
+spec:
+  hosts:
+  - httpbin.org
+#  location: MESH_EXTERNAL
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: outbound-connector
+spec:
+  gateways:
+    - istio-egressgateway
+#    - mesh
+  hosts:
+    - httpbin.org
+  http:
+    - route:
+      - destination:
+          host: httpbin.org
+        # headers:
+        #   request:
+        #     add:
+        #       xxx: yyy

--- a/deployment/orion_adapter_service.yaml
+++ b/deployment/orion_adapter_service.yaml
@@ -12,6 +12,10 @@ spec:
     protocol: TCP
     port: 43210
     targetPort: 43210
+  - name: http
+    protocol: TCP
+    port: 54321
+    targetPort: 54321
   selector:
     app: orionadapter
 ---
@@ -41,3 +45,6 @@ spec:
         imagePullPolicy: Never
         ports:
         - containerPort: 43210
+          name: grpc
+        - containerPort: 54321
+          name: http

--- a/orionadapter/grpc/httpendpoint.go
+++ b/orionadapter/grpc/httpendpoint.go
@@ -1,0 +1,56 @@
+package grpc
+
+// TODO: stop gap solution to https://github.com/orchestracities/boost/issues/24
+// Sort out egress routing, then ditch this code and the Envoy filter.
+
+import (
+	"fmt"
+	"net/http"
+
+	ilog "istio.io/pkg/log"
+
+	"github.com/orchestracities/boost/orionadapter/codegen/config"
+	"github.com/orchestracities/boost/orionadapter/handler"
+)
+
+var currentAdapterConfig *config.Params = nil
+
+// TODO: concurrency!! currentAdapterConfig gets shared between gRPC
+// and HTTP servers!!
+// TODO: currentAdapterConfig will be nil until the first incoming
+// request for Orion hits the mesh---see server.HandleOrionadapter.
+// Hence any notification Orion will send before then, will have
+// no DAPS server token!!
+
+func token(w http.ResponseWriter, req *http.Request) {
+	logRequest(req)
+
+	if currentAdapterConfig == nil {
+		msg := "http endpoint hasn't been initialized yet"
+		ilog.Errorf("%s", msg)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+
+	serverToken, err := handler.GenerateToken(currentAdapterConfig)
+	if err != nil {
+		ilog.Errorf("error generating server token: %v", err)
+		http.Error(w, "error generating server token",
+			http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprintf(w, serverToken)
+}
+
+// RunHTTPServerLoop enters the HTTP server loop.
+func RunHTTPServerLoop(port string) {
+	http.HandleFunc("/", token)
+	addr := fmt.Sprintf(":%s", port)
+
+	http.ListenAndServe(addr, nil)
+}
+
+func logRequest(r *http.Request) {
+	ilog.Infof("internal http token request: %s %v\n", r.RemoteAddr, r.Header)
+}

--- a/orionadapter/grpc/server.go
+++ b/orionadapter/grpc/server.go
@@ -38,6 +38,12 @@ var _ od.HandleOrionadapterServiceServer = &OrionAdapter{}
 // call to our handler.
 func (s *OrionAdapter) HandleOrionadapter(ctx context.Context,
 	r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse, error) {
+	if cfg, err := handler.GetConfig(r); err == nil {
+		currentAdapterConfig = cfg
+	}
+	// TODO: get rid of above code once this gets sorted:
+	// - https://github.com/orchestracities/boost/issues/24
+
 	return handler.Authorize(r)
 }
 
@@ -46,8 +52,8 @@ func (s *OrionAdapter) Addr() string {
 	return s.listener.Addr().String()
 }
 
-// Run starts the server loop and exits on receving a shutdown singnal,
-// i.e. any data sent over the shutdown channel.
+// Run starts the server loop and, on exit, sends any server error over the
+// shutdown channel.
 func (s *OrionAdapter) Run(shutdown chan error) {
 	shutdown <- s.server.Serve(s.listener)
 }

--- a/orionadapter/handler/auth.go
+++ b/orionadapter/handler/auth.go
@@ -18,7 +18,7 @@ import (
 func Authorize(r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse, error) {
 	ilog.Infof("auth request: %v\n", *r)
 
-	params, err := getConfig(r)
+	params, err := GetConfig(r)
 	pubKeyPemRep, err := getIdsaPublicKey(params, err)
 	if err != nil {
 		ilog.Errorf("%v", err)
@@ -35,7 +35,7 @@ func Authorize(r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse,
 		return invalidJWTError(), nil
 	}
 
-	serverToken, err := generateToken(params)
+	serverToken, err := GenerateToken(params)
 	if err != nil {
 		ilog.Errorf("error generating server token: %v\n", err)
 		return tokenGenError(), nil
@@ -52,7 +52,9 @@ func validateToken(pubKey string, headerValue string) error {
 	return token.Validate(pubKey, jwt)
 }
 
-func generateToken(p *config.Params) (string, error) {
+// GenerateToken gets a new ID token from DAPS, puts it into the configured
+// server header JSON object and then Base64 encodes the JSON object.
+func GenerateToken(p *config.Params) (string, error) {
 	daps, err := buildDapsIDRequest(p)
 	idTokenTemplate, err := getIDTokenJSONTemplate(p, err)
 	if err != nil {

--- a/orionadapter/handler/cfgreader.go
+++ b/orionadapter/handler/cfgreader.go
@@ -20,7 +20,8 @@ func missingFieldError(fieldName string) error {
 	return fmt.Errorf("no value for adapter config field: %s", fieldName)
 }
 
-func getConfig(r *od.HandleOrionadapterRequest) (*config.Params, error) {
+// GetConfig extracts adapter configuration from the Mixer request.
+func GetConfig(r *od.HandleOrionadapterRequest) (*config.Params, error) {
 	cfg := &config.Params{}
 
 	if r.AdapterConfig == nil {

--- a/orionadapter/main.go
+++ b/orionadapter/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"net/http"
 	"os"
 	"strconv"
 
@@ -37,20 +35,10 @@ func readPortArg() int {
 	return 0
 }
 
-// TODO: refactor this mess!!
-
-func token(w http.ResponseWriter, req *http.Request) {
-	fmt.Fprintf(w, "whoopsie.dapsie!!")
-}
-
-func runHTTPServerLoop(port string) {
-	http.HandleFunc("/", token)
-	addr := fmt.Sprintf(":%s", port)
-
-	log.Fatal(http.ListenAndServe(addr, nil))
-}
+// TODO: get rid of below code once this gets sorted:
+// - https://github.com/orchestracities/boost/issues/24
 
 func runHTTP() {
 	port := os.Args[2] // TODO let it bomb out if no arg?!
-	go runHTTPServerLoop(port)
+	go grpc.RunHTTPServerLoop(port)
 }

--- a/orionadapter/main.go
+++ b/orionadapter/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"net/http"
 	"os"
 	"strconv"
 
@@ -20,6 +22,9 @@ func main() {
 	go func() {
 		s.Run(shutdown)
 	}()
+
+	runHTTP()
+
 	_ = <-shutdown
 }
 
@@ -30,4 +35,22 @@ func readPortArg() int {
 		}
 	}
 	return 0
+}
+
+// TODO: refactor this mess!!
+
+func token(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "whoopsie.dapsie!!")
+}
+
+func runHTTPServerLoop(port string) {
+	http.HandleFunc("/", token)
+	addr := fmt.Sprintf(":%s", port)
+
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+func runHTTP() {
+	port := os.Args[2] // TODO let it bomb out if no arg?!
+	go runHTTPServerLoop(port)
 }


### PR DESCRIPTION
This PR implements a stopgap solution to adding DAPS ID token headers to requests originating from Orion and directed to a remote IDS connector outside the mesh.


### Functionality overview
When Orion sends an HTTP request to a remote IDS connector (typically to notify of entity updates), a DAPS ID token needs to be added to the outgoing request so that the remote connector can identify the sender. This PR implements exactly that. We get the token from a configured DAPS service through mTLS, insert it in an IDS JSON "result message", Base64-encode the JSON, and add a header to the request. The header's name is `header` and its value is the Base64 block.

Does it ring a bell? Well, that's pretty much what we did already for Orion HTTP responses to requests from a remote client (a.k.a. consumer) connector. In fact, we're supposed to add the IDS ID header identifying Orion to both responses to consumer connectors (PR #16) and requests to server (a.k.a. provider) connectors, which is what this PR does.


### Implementation overview
Having the ID token implementation for responses (PR #16), you'd think we should've been able to just reuse it as is and plonk the ID token in Orion requests by dint of Istio config. While that was the plan, it didn't pan out---see #24. As a workaround, this PR implements:

* an **adapter HTTP endpoint** where you can get a Base64-encoded IDS JSON "result message" with an Orion DAPS ID token in it; and 
* an **Envoy filter** to intercept Orion requests, get the Base64 block from the adapter HTTP endpoint and add the IDS header to the request.

The HTTP endpoint reuses PR #16's `GenerateToken` function to get an ID token from DAPS and produce the output Base64 block. Notice though that to do that, the HTTP endpoint has to be able to get hold of Istio adapter config data. Where does it get it from? Well, the Mixer always calls the adapter's gRPC endpoint with the current config, so on getting that data, the adapter caches it in memory so that it'll be available to any subsequent call to the HTTP endpoint.


### Shortcomings

1. The adapter is stateful (config data cache) even though it runs on K8s pretending to be a stateless workload, so e.g. it can't be replicated.
2. The HTTP endpoint won't be able to get a DAPS token until such a time the Mixer hits the adapter gRPC endpoint for the first time---the Mixer calls the adapter whenever an HTTP request for Orion comes into the mesh.
3. Because of (2), whenever the operator reconfigures the adapter (e.g. `kubeclt apply -f new-istio-cfg.yaml`), they should also make a dummy call to Orion straight afterwards (e.g. `GET /v2`) so that the Mixer calls the adapter with the new config. Otherwise later calls to the HTTP endpoint may fail due to a stale cache.
4. Ditto for image deployments and pod restarts. Restarts are a problem since in general you won't know when K8s will do that or for that matter when the pod gets relocated to another node.
5. Security needs tightening. The HTTP endpoint blindly returns the token, no questions asked. While the endpoint isn't exposed outside the mesh, this isn't obviously optimal.
6. Fragile Lua script---see Envoy filter.

See #24 for what to do about these sore points.