### PR TITLE
Sec ops caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ it (i.e. set `disablePolicyChecks` to `false`) but it doesn't nor does it
 work to specify that option at installation time which is why you'll have
 to manually edit the K8s config after applying the Istio `demo` profile.
 
+**Tip**. *Istio Dashboard*. If you're looking for an easy way to see
+what's going on in your mesh (services, logs, config, etc.), why not
+use the Kiali dashboard installed with the demo profile? Try
+
+    $ istioctl dashboard kiali
+
+Log in with user `admin` and password `admin`.
+
 ##### Adapter and mock DAPS images
 
 Let's "Dockerise" our adapter so we can run it on the freshly minted Istio
@@ -219,7 +227,8 @@ You should get back a fat 403 with a message along the lines of:
 
 Like I said earlier, the adapter verifies the JWT you send as part of the IDSA-Header is valid---see
 `deployment/sample_operator_cfg.yaml`. What happens if we send a valid
-token then? Here's a valid JWT signed with the private key in the config.
+token then? Here's a valid JWT signed with the private key in the config
+(`idsa_private_key` field).
 
     $ export MY_FAT_JWT=eyJhbGciOiJSUzI1NiJ9.e30.QHOtHczHK_bJrgqhXeZdE4xnCGh9zZhp67MHfRzHlUUe98eCup_uAEKh-2A8lCyg8sr1Q9dV2tSbB8vPecWPaB43BWKU00I7cf1jRo9Yy0nypQb3LhFMiXIMhX6ETOyOtMQu1dS694ecdPxMF1yw4rgqTtp_Sz-JfrasMLcxpBtT7USocnJHE_EkcQKVXeJ857JtkCKAzO4rkMli2sFnKckvoJMBoyrObZ_VFCVR5NGnOvSnLMqKrYaLxNHLDL_0Mxy_b8iKTiRAqyNce4tg8Evhqb3rPQcx9kMdwyv_1ggEVKQyiPWa3MkSBvBArgPghbJMcSJVMhtUO8M9BmNMyw
 
@@ -384,10 +393,10 @@ through port `31026`. Next deploy Orion
 
 and you're ready to play around! Here's how to get your feet wet:
 
-    $ curl -v "$(minikube ip):31026"/v2
+    $ curl -v "$(minikube ip):31026/v2"
     # you should get back a 403/permission denied.
 
-    $ curl -v "$(minikube ip):31026"/v2 -H "header:${HEADER_VALUE}"
+    $ curl -v "$(minikube ip):31026/v2" -H "header:${HEADER_VALUE}"
     # set HEADER_VALUE as we did earlier; you should get back some
     # JSON with Orion's API entry points.
 
@@ -396,6 +405,76 @@ It should all go without a hitch, but there's a snag: because of
 [#28](https://github.com/orchestracities/boost/issues/28), at the
 moment no IDS header gets added to Orion notification messages. But
 a fix should become available soon soon, stay tuned!
+
+##### Access-control with AuthZ
+
+Time to up the ante in the access-control war. We're going to require
+CIA clearance now before you can access HTTP resources---in case that
+wasn't obvious to you too, CIA stands for Control of Internet Access,
+of course, what else?! We have an AuthZ test server at
+
+* http://authzforceingress.appstorecontainerns.46.17.108.63.xip.io/authzforce-ce/domains/CYYY_V2IEeqMJKbegCuurA/pdp
+
+configured with an XACML policy that only lets users in roles `role0`
+through `role3` `GET` Orion resources through an application identified
+by a resource ID of `b3a4a7d2-ce61-471f-b05d-fb82452ae686`, i.e. our
+Mr Adapter the Constable. Also, the policy only gives the green light
+if the resource the user is trying to access belongs to the `service`
+tenant.
+
+With default config, the adapter won't ask AuthZ to authorize calls:
+if the incoming token is valid, the request gets forwarded to Orion.
+But you can change that in a flash. Edit `sample_operator_cfg.yaml`
+to set the `authz/enable` flag to `true`, then
+
+    $ kubectl apply -f deployment/sample_operator_cfg.yaml
+
+Now whenever a request comes in, after okaying the client token in the
+`header` header, the adapter will submit an authorization request to
+AuthZ with the below data:
+
+* *Resource ID*. Taken from `authz` config section.
+* *Resource Path*. The incoming request path, e.g. `/v2/entities?id=1`.
+* *Action*. Request verb, e.g. `GET`.
+* *Tenant*. Content of the request's `Fiware-Service` header if any.
+* *Roles*. User roles extracted from the `scopes` claim, if any, in
+  the incoming JWT token payload.
+
+Let's see it in action. Try resubmitting the request we made earlier
+to get Orion's API entry points
+
+    $ curl -v "$(minikube ip):31026/v2" -H "header:${HEADER_VALUE}"
+
+and, surprise, surprise, the adapter should show you the door this
+time (the boy ain't got no manners!) with a `403` and a message like
+
+    PERMISSION_DENIED:
+    orionadapter-handler.handler.istio-system:unauthorized:
+    AuthZ denied authorization
+
+Let's see if we can get through. Since AuthZ expects the user to be
+in `role0` through `role3` and the request to target the `service`
+tenant, we'll need to change our request so it holds that data too.
+So we're going to use a JWT with a `scopes` claim set to `[role0, role1,
+role2, role3]` and add a `Fiware-Service` header. Here's the JWT,
+signed with the private key in the adapter config---look for the
+`idsa_private_key` field in `sample_operator_cfg.yaml`.
+
+    $ export MY_FAT_JWT=eyJhbGciOiJSUzI1NiJ9.eyJzY29wZXMiOlsicm9sZTAiLCJyb2xlMSIsInJvbGUyIiwicm9sZTMiXX0.JN66SWLPqNg7pqTFRcryo-3lX4V4BNKG5bZD3SDne4B3qV5kS-5NNW5wFkty870NFjuXP_nCxg3ayOCe8YZab3kRieaCeygVJwc2i1iUEHmYqKz6jx2EecfM2VbechaapDOFc9k01S5ea1t7fSHFsJsDWpVPpCJZBAv1ikPZrv88-7PLOacdGum--0-0gI6LGaXIFiTIAzbdeJ5V-ikIK7CgLJFaR3Ib5MwGRjrGTaPqQGE62SVpATphRhSJIfXm18ViF2fG7KTGPBYGY3rxAdy6l3klpKuxA0ATQRZJ39mpjrgbf-WVlvH_9nSFAn9BvLiSJohpSMmoJTX7ToWA0g
+
+Just like we did earlier, we use the same convenience script to get
+the base64-encoded IDSA header
+
+    $ export HEADER_VALUE=$(sh scripts/idsa-header-value.sh "${MY_FAT_JWT}")
+
+and we're ready to try our luck
+
+    $ curl -v "$(minikube ip):31026/v2" \
+           -H "header:${HEADER_VALUE}"  \
+           -H "Fiware-Service:service"
+
+If everything went according to plan, you're looking at a `200`
+response on your terminal with the JSON body returned by Orion :-)
 
 ##### Cleaning up
 

--- a/deployment/sample_operator_cfg.yaml
+++ b/deployment/sample_operator_cfg.yaml
@@ -8,6 +8,10 @@ spec:
   connection:
     address: "orionadapterservice:43210"
   params:
+    authz:
+      enabled: false
+      resource_id: "b3a4a7d2-ce61-471f-b05d-fb82452ae686"
+      server_url: "http://authzforceingress.appstorecontainerns.46.17.108.63.xip.io/authzforce-ce/domains/CYYY_V2IEeqMJKbegCuurA/pdp"
     daps:
       connector_audience: "https://consumerconnector.fiware.org"
       connector_certificate: "-----BEGIN CERTIFICATE-----\nMIIDhjCCAm4CCQCjAJ8YHrjCoTANBgkqhkiG9w0BAQsFADCBhDELMAkGA1UEBhMC\nWkExFTATBgNVBAgMDFdlc3Rlcm4gQ2FwZTESMBAGA1UEBwwJQ2FwZSBUb3duMRIw\nEAYDVQQKDAlSdXNrcyBMdGQxCzAJBgNVBAsMAk1hMSkwJwYDVQQDDCBvcmlvbmFk\nYXB0ZXJzZXJ2aWNlLmlzdGlvLXN5c3RlbTAeFw0yMDAxMTkxNjU3NDBaFw0zMDAx\nMTYxNjU3NDBaMIGEMQswCQYDVQQGEwJaQTEVMBMGA1UECAwMV2VzdGVybiBDYXBl\nMRIwEAYDVQQHDAlDYXBlIFRvd24xEjAQBgNVBAoMCVJ1c2tzIEx0ZDELMAkGA1UE\nCwwCTWExKTAnBgNVBAMMIG9yaW9uYWRhcHRlcnNlcnZpY2UuaXN0aW8tc3lzdGVt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl8saBGDth0LkrGrpYx3U\np7u933TN4mjCZtofQfhKy5D1T6QWhkhPTTX0xyLwwNCd+ckzj6oImubI9glL4/7v\n+lqvXQDDyIwc8rSzQTDSsoLG1hJkJztYR08AQoercNuclvyc67c8mqYSsVO+VTCh\nudTkena8H4VdT+LcaufbwUGCd7R89uUjtco7mK66mxKbxh/wd9FNfWG8ky7QoSnR\nrAbGJCcNng1z1htaFE8IQtE3vn85uhPJBsvaQmUFX8AIxAVTblF74dnjlYH6hFnP\nfU+edH3lwiBRCM5Ur7Tqhorm1NcUkrFKzGrA6CxlEKZJ7RgPZC9PCabBKjzvZRLQ\nhQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAiQkBJ46qfeRJx4Fpq87+cgSORjts2\nAxonWW4anz8zhvH73Re5//1WlY5bXDB4Rpejm0LPZ/XzVI9kbULg4JYJd0p8eTr8\noiab1XNI9M6WHBAzF/dWse3IXErlBQAESmX051AGEtLg74jZTC4oNCcfsBy4oYPL\n5QxIoDwBvmi+ntrXLRm/16Mb/UCQ7XXwP1lugvt9x96hHCTXK/83QK86ooZmchIi\ncrXpKrVFy/oDLt9YIfT6KEtWmmquAIaA6UDc3UI7kqR2mmsYn/d3zy79CPT7NnpK\nTHZ0oKtoMSSZS23DyuP3Q0K6JHXMfPBWKPaKSHLUMVaORvGZLmQ9cEvf\n-----END CERTIFICATE-----\n"
@@ -29,7 +33,10 @@ metadata:
   namespace: "istio-system"
 spec:
   params:
-    client_token: "request.headers[\"header\"]"
+    client_token: "request.headers[\"header\"] | \"\""
+    fiware_service: "request.headers[\"fiware-service\"] | \"\""
+    request_method: request.method
+    request_path: request.path
   template: oriondata
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/orchestracities/boost
 go 1.13
 
 require (
+	github.com/dgraph-io/ristretto v0.0.2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gogo/protobuf v1.3.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/cactus/go-statsd-client v3.1.1+incompatible/go.mod h1:cMRcwZDklk7hXp+
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
@@ -91,8 +92,11 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dchest/siphash v1.1.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
 github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
+github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
+github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
@@ -450,6 +454,8 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/orionadapter/cache/bootstrap.go
+++ b/orionadapter/cache/bootstrap.go
@@ -1,0 +1,18 @@
+package cache
+
+// NOTE. Concurrency. Treat this var as a const, you can't touch this :-)
+var cached *store
+
+// Init gets the cache infrastructure ready for use.
+// It must be the first call to this module and must be done in the main
+// function before any other thread can possibly call the functions this
+// module exports.
+func Init() error {
+	s, err := newStore()
+	if err != nil {
+		return err
+	}
+
+	cached = s
+	return nil
+}

--- a/orionadapter/cache/keys.go
+++ b/orionadapter/cache/keys.go
@@ -1,0 +1,32 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+
+	token "github.com/orchestracities/boost/orionadapter/sec"
+	"github.com/orchestracities/boost/orionadapter/sec/authz"
+)
+
+const adapterConfigKey = "adapterConfigKey"
+const dapsIDTokenKey = "dapsIDTokenKey"
+
+func authZCallKey(idsClientHeader string, callParams *authz.Request) (
+	key string, clientJWT string, err error) {
+	clientJWT, err = token.ReadClientToken(idsClientHeader)
+	if err != nil {
+		return "", "", err
+	}
+	if callParams == nil {
+		return "", "", errors.New("authZCallKey: nil callParams")
+	}
+
+	return makeKey(clientJWT, callParams), clientJWT, nil
+}
+
+// NOTE. Fast hashing. Ristretto's default KeyToHash function converts a
+// string to a []byte and then uses xxHash to get the actual hash which
+// is great. So we only need to convert our structs to string.
+func makeKey(clientJWT string, callParams *authz.Request) string {
+	return fmt.Sprintf("(%v, %v)", clientJWT, callParams)
+}

--- a/orionadapter/cache/keys.go
+++ b/orionadapter/cache/keys.go
@@ -4,16 +4,16 @@ import (
 	"errors"
 	"fmt"
 
-	token "github.com/orchestracities/boost/orionadapter/sec"
 	"github.com/orchestracities/boost/orionadapter/sec/authz"
+	"github.com/orchestracities/boost/orionadapter/sec/consumer"
 )
 
 const adapterConfigKey = "adapterConfigKey"
 const dapsIDTokenKey = "dapsIDTokenKey"
 
-func authZCallKey(idsClientHeader string, callParams *authz.Request) (
-	key string, clientJWT string, err error) {
-	clientJWT, err = token.ReadClientToken(idsClientHeader)
+func authZCallKey(idsConsumerHeader string, callParams *authz.Request) (
+	key string, consumerJWT string, err error) {
+	consumerJWT, err = consumer.ReadToken(idsConsumerHeader)
 	if err != nil {
 		return "", "", err
 	}
@@ -21,12 +21,12 @@ func authZCallKey(idsClientHeader string, callParams *authz.Request) (
 		return "", "", errors.New("authZCallKey: nil callParams")
 	}
 
-	return makeKey(clientJWT, callParams), clientJWT, nil
+	return makeKey(consumerJWT, callParams), consumerJWT, nil
 }
 
 // NOTE. Fast hashing. Ristretto's default KeyToHash function converts a
 // string to a []byte and then uses xxHash to get the actual hash which
 // is great. So we only need to convert our structs to string.
-func makeKey(clientJWT string, callParams *authz.Request) string {
-	return fmt.Sprintf("(%v, %v)", clientJWT, callParams)
+func makeKey(consumerJWT string, callParams *authz.Request) string {
+	return fmt.Sprintf("(%v, %v)", consumerJWT, callParams)
 }

--- a/orionadapter/cache/keys_test.go
+++ b/orionadapter/cache/keys_test.go
@@ -1,0 +1,70 @@
+package cache
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/orchestracities/boost/orionadapter/sec/authz"
+)
+
+const clientJSONPayloadTemplate string = `{
+	"securityToken": {
+		"tokenValue": "%s"
+	}
+}`
+
+func toB64(headerValue string) string {
+	v := []byte(headerValue)
+	return base64.StdEncoding.EncodeToString(v)
+}
+
+func clientJSONPayload(token string) string {
+	headerValue := fmt.Sprintf(clientJSONPayloadTemplate, token)
+	return toB64(headerValue)
+}
+
+func callParams(roles []string, path string, service string,
+	action string) *authz.Request {
+	return &authz.Request{
+		Roles:         roles,
+		ResourceID:    "b3a4a7d2-ce61-471f-b05d-fb82452ae686",
+		ResourcePath:  path,
+		FiwareService: service,
+		Action:        action,
+	}
+}
+
+func TestAuthZCallKeyContent(t *testing.T) {
+	header := clientJSONPayload("my.fat.jwt")
+	params := callParams([]string{"r1"}, "/v2", "svc", "GET")
+
+	got, _, err := authZCallKey(header, params)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	for _, v := range []string{"my.fat.jwt", "r1", "/v2", "GET"} {
+		if !strings.Contains(got, v) {
+			t.Errorf("%v not in %v", v, got)
+		}
+	}
+}
+
+func TestAuthZCallKeyErrorOnNilCallParams(t *testing.T) {
+	header := clientJSONPayload("my.fat.jwt")
+	got, _, err := authZCallKey(header, nil)
+	if err == nil {
+		t.Errorf("want error; got: %v", got)
+	}
+}
+
+func TestAuthZCallKeyErrorOnInvalidHeader(t *testing.T) {
+	header := ""
+	params := callParams([]string{"r1"}, "/v2", "svc", "GET")
+	got, _, err := authZCallKey(header, params)
+	if err == nil {
+		t.Errorf("want error; got: %v", got)
+	}
+}

--- a/orionadapter/cache/lookup.go
+++ b/orionadapter/cache/lookup.go
@@ -46,9 +46,9 @@ func LookupDapsIDToken() (token string, found bool) {
 
 // LookupAuthZDecision gets any cached AuthZ decision for the specified
 // call parameters. Use the found flag to tell if the lookup was successful.
-func LookupAuthZDecision(idsClientHeader string, callParams *authz.Request) (
+func LookupAuthZDecision(idsConsumerHeader string, callParams *authz.Request) (
 	authorized bool, found bool) {
-	key, _, err := authZCallKey(idsClientHeader, callParams)
+	key, _, err := authZCallKey(idsConsumerHeader, callParams)
 	if err != nil {
 		return false, false
 	}

--- a/orionadapter/cache/lookup.go
+++ b/orionadapter/cache/lookup.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"github.com/orchestracities/boost/orionadapter/codegen/config"
+	"github.com/orchestracities/boost/orionadapter/sec/authz"
+)
+
+func asBool(value interface{}, found bool) (bool, bool) {
+	if found {
+		if converted, ok := value.(bool); ok {
+			return converted, true
+		}
+	}
+	return false, false
+}
+
+func asString(value interface{}, found bool) (string, bool) {
+	if found {
+		if converted, ok := value.(string); ok {
+			return converted, true
+		}
+	}
+	return "", false
+}
+
+func asParams(value interface{}, found bool) (*config.Params, bool) {
+	if found {
+		if converted, ok := value.(*config.Params); ok {
+			return converted, true
+		}
+	}
+	return nil, false
+}
+
+// LookupAdapterConfig gets any cached adapter config. Use the found flag
+// to tell if the lookup was successful.
+func LookupAdapterConfig() (params *config.Params, found bool) {
+	return asParams(cached.Config().lookup(adapterConfigKey))
+}
+
+// LookupDapsIDToken gets any cached DAPS ID token. Use the found flag
+// to tell if the lookup was successful.
+func LookupDapsIDToken() (token string, found bool) {
+	return asString(cached.Daps().lookup(dapsIDTokenKey))
+}
+
+// LookupAuthZDecision gets any cached AuthZ decision for the specified
+// call parameters. Use the found flag to tell if the lookup was successful.
+func LookupAuthZDecision(idsClientHeader string, callParams *authz.Request) (
+	authorized bool, found bool) {
+	key, _, err := authZCallKey(idsClientHeader, callParams)
+	if err != nil {
+		return false, false
+	}
+	return asBool(cached.AuthZ().lookup(key))
+}

--- a/orionadapter/cache/put.go
+++ b/orionadapter/cache/put.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"github.com/orchestracities/boost/orionadapter/codegen/config"
+	token "github.com/orchestracities/boost/orionadapter/sec"
+	"github.com/orchestracities/boost/orionadapter/sec/authz"
+)
+
+// PutAdapterConfig caches adapter config. Use the ok flag to tell if the
+// operation was successful.
+func PutAdapterConfig(params *config.Params) (ok bool) {
+	if params == nil {
+		return false
+	}
+	return cached.Config().keep(adapterConfigKey, params)
+}
+
+// PutDapsIDToken caches a DAPS ID token. Use the ok flag to tell if the
+// operation was successful.
+func PutDapsIDToken(jwt string) (ok bool) {
+	if len(jwt) == 0 {
+		return false
+	}
+	ttl := token.FromRaw(jwt).ExpiresIn()
+	return cached.Daps().put(dapsIDTokenKey, jwt, 1, ttl)
+}
+
+// PutAuthZDecision caches an AuthZ decision. Use the ok flag to tell if the
+// operation was successful.
+func PutAuthZDecision(idsClientHeader string, callParams *authz.Request,
+	authorized bool) (ok bool) {
+	key, jwt, err := authZCallKey(idsClientHeader, callParams)
+	if err != nil {
+		return false
+	}
+	ttl := token.FromRaw(jwt).ExpiresIn()
+	return cached.AuthZ().put(key, authorized, 1, ttl)
+}

--- a/orionadapter/cache/put.go
+++ b/orionadapter/cache/put.go
@@ -2,8 +2,8 @@ package cache
 
 import (
 	"github.com/orchestracities/boost/orionadapter/codegen/config"
-	token "github.com/orchestracities/boost/orionadapter/sec"
 	"github.com/orchestracities/boost/orionadapter/sec/authz"
+	"github.com/orchestracities/boost/orionadapter/sec/jwt"
 )
 
 // PutAdapterConfig caches adapter config. Use the ok flag to tell if the
@@ -17,22 +17,22 @@ func PutAdapterConfig(params *config.Params) (ok bool) {
 
 // PutDapsIDToken caches a DAPS ID token. Use the ok flag to tell if the
 // operation was successful.
-func PutDapsIDToken(jwt string) (ok bool) {
-	if len(jwt) == 0 {
+func PutDapsIDToken(jwtData string) (ok bool) {
+	if len(jwtData) == 0 {
 		return false
 	}
-	ttl := token.FromRaw(jwt).ExpiresIn()
-	return cached.Daps().put(dapsIDTokenKey, jwt, 1, ttl)
+	ttl := jwt.FromRaw(jwtData).ExpiresIn()
+	return cached.Daps().put(dapsIDTokenKey, jwtData, 1, ttl)
 }
 
 // PutAuthZDecision caches an AuthZ decision. Use the ok flag to tell if the
 // operation was successful.
 func PutAuthZDecision(idsClientHeader string, callParams *authz.Request,
 	authorized bool) (ok bool) {
-	key, jwt, err := authZCallKey(idsClientHeader, callParams)
+	key, jwtData, err := authZCallKey(idsClientHeader, callParams)
 	if err != nil {
 		return false
 	}
-	ttl := token.FromRaw(jwt).ExpiresIn()
+	ttl := jwt.FromRaw(jwtData).ExpiresIn()
 	return cached.AuthZ().put(key, authorized, 1, ttl)
 }

--- a/orionadapter/cache/put.go
+++ b/orionadapter/cache/put.go
@@ -27,9 +27,9 @@ func PutDapsIDToken(jwtData string) (ok bool) {
 
 // PutAuthZDecision caches an AuthZ decision. Use the ok flag to tell if the
 // operation was successful.
-func PutAuthZDecision(idsClientHeader string, callParams *authz.Request,
+func PutAuthZDecision(idsConsumerHeader string, callParams *authz.Request,
 	authorized bool) (ok bool) {
-	key, jwtData, err := authZCallKey(idsClientHeader, callParams)
+	key, jwtData, err := authZCallKey(idsConsumerHeader, callParams)
 	if err != nil {
 		return false
 	}

--- a/orionadapter/cache/putlookup_test.go
+++ b/orionadapter/cache/putlookup_test.go
@@ -1,0 +1,242 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/orchestracities/boost/orionadapter/codegen/config"
+)
+
+func ensureInit(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Errorf("failed to initialize cache: %v", err)
+	}
+}
+
+func TestStoreAndRetrieveAdapterConfig(t *testing.T) {
+	ensureInit(t)
+
+	cfg := &config.Params{IdsaPublicKey: "k"}
+	if ok := PutAdapterConfig(cfg); !ok {
+		t.Error("failed to put config")
+	}
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	got, found := LookupAdapterConfig()
+	if !found {
+		t.Errorf("config not found, got: %v", got)
+	}
+	if got != cfg { // ptr comp, both must point to same place on heap
+		t.Errorf("want: %v; got: %v", cfg, got)
+	}
+	if got.IdsaPublicKey != cfg.IdsaPublicKey {
+		t.Errorf("want: %v; got: %v", cfg.IdsaPublicKey, got.IdsaPublicKey)
+	}
+}
+
+func TestDropNilAdapterConfig(t *testing.T) {
+	ensureInit(t)
+
+	cfg := &config.Params{IdsaPublicKey: "k"}
+	if ok := PutAdapterConfig(cfg); !ok {
+		t.Error("failed to put config")
+	}
+	if ok := PutAdapterConfig(nil); ok {
+		t.Error("should've refused to put nil config")
+	}
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	got, found := LookupAdapterConfig()
+	if !found {
+		t.Errorf("old config not found, got: %v", got)
+	}
+	if got != cfg { // ptr comp, both must point to same place on heap
+		t.Errorf("want old config: %v; got: %v", cfg, got)
+	}
+}
+
+func TestNoCachedAdapterConfig(t *testing.T) {
+	ensureInit(t)
+
+	got, found := LookupAdapterConfig()
+	if found {
+		t.Errorf("no config but found: %v", got)
+	}
+}
+
+// tokens generated on jwt.io
+//                     { alg: HS256 }.{}.sig
+const emptyJWT = `eyJhbGciOiJIUzI1NiJ9.e30.ZRrHA1JJJW8opsbCGfG_HACGpVUMN_a9IV7pAx_Zmeo`
+
+//                     { alg: HS256 }.{ exp: 10 }.sig
+const expiredJWT = `eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjEwfQ.aPE8oUjuqjmcV-jE_Z9tEiaEn-4wpIjjHY7kzxtB85Q`
+
+//                     { alg: HS256 }.{ exp: 2524608000 }.sig
+//                                          ^ 01 Jan 2050
+const expIn2050JWT = `eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjI1MjQ2MDgwMDB9.e2QtHNDKYdYvbdu95KY6xfcHppvkSOuNBhx2Y-8XYQY`
+
+func TestStoreAndRetrieveDapsIDToken(t *testing.T) {
+	ensureInit(t)
+
+	if ok := PutDapsIDToken(expIn2050JWT); !ok {
+		t.Error("failed to put daps id token")
+	}
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	got, found := LookupDapsIDToken()
+	if !found {
+		t.Errorf("daps id token not found, got: %v", got)
+	}
+	if got != expIn2050JWT {
+		t.Errorf("want: %v; got: %v", expIn2050JWT, got)
+	}
+}
+
+func TestDropExpiredDapsIDToken(t *testing.T) {
+	ensureInit(t)
+
+	if ok := PutDapsIDToken(expiredJWT); ok {
+		t.Error("should've refused to put expired daps id token")
+	}
+
+	got, found := LookupDapsIDToken()
+	if found {
+		t.Errorf("daps id token found: %v", got)
+	}
+}
+
+func TestDropDapsIDTokenWithNoExp(t *testing.T) {
+	ensureInit(t)
+
+	if ok := PutDapsIDToken(emptyJWT); ok {
+		t.Error("should've refused to put daps id token with no exp")
+	}
+
+	got, found := LookupDapsIDToken()
+	if found {
+		t.Errorf("daps id token found: %v", got)
+	}
+}
+
+func TestDropEmptyStringDapsIDToken(t *testing.T) {
+	ensureInit(t)
+
+	if ok := PutDapsIDToken(expIn2050JWT); !ok {
+		t.Error("failed to put daps id token")
+	}
+	if ok := PutDapsIDToken(""); ok {
+		t.Error("should've refused to put empty string")
+	}
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	got, found := LookupDapsIDToken()
+	if !found {
+		t.Errorf("old daps id token not found, got: %v", got)
+	}
+	if got != expIn2050JWT {
+		t.Errorf("want old daps id token: %v; got: %v", expIn2050JWT, got)
+	}
+}
+
+func TestNoCachedDapsIDToken(t *testing.T) {
+	ensureInit(t)
+
+	got, found := LookupDapsIDToken()
+	if found {
+		t.Errorf("daps id token found: %v", got)
+	}
+}
+
+func TestStoreAndRetrieveAuthZDecision(t *testing.T) {
+	ensureInit(t)
+
+	header := clientJSONPayload(expIn2050JWT)
+	params := callParams([]string{"r1"}, "/v2", "svc", "GET")
+	authorized := true
+
+	if ok := PutAuthZDecision(header, params, authorized); !ok {
+		t.Error("failed to put authz decision")
+	}
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	got, found := LookupAuthZDecision(header, params)
+	if !found {
+		t.Errorf("authz decision not found, got: %v", got)
+	}
+	if got != authorized {
+		t.Errorf("want: %v; got: %v", authorized, got)
+	}
+}
+
+func TestDropAuthZDecisionWhenClientTokenExpired(t *testing.T) {
+	ensureInit(t)
+
+	header := clientJSONPayload(expiredJWT)
+	params := callParams([]string{"r1"}, "/v2", "svc", "GET")
+	authorized := true
+
+	if ok := PutAuthZDecision(header, params, authorized); ok {
+		t.Error("should refuse to put authz decision if JWT has expired")
+	}
+
+	got, found := LookupAuthZDecision(header, params)
+	if found {
+		t.Errorf("authz decision found: %v", got)
+	}
+}
+
+func TestDropAuthZDecisionWhenClientTokenWithNoExp(t *testing.T) {
+	ensureInit(t)
+
+	header := clientJSONPayload(emptyJWT)
+	params := callParams([]string{"r1"}, "/v2", "svc", "GET")
+	authorized := true
+
+	if ok := PutAuthZDecision(header, params, authorized); ok {
+		t.Error("should refuse to put authz decision if JWT has no exp")
+	}
+
+	got, found := LookupAuthZDecision(header, params)
+	if found {
+		t.Errorf("authz decision found: %v", got)
+	}
+}
+
+func TestDropAuthZDecisionWhenInvalidClientToken(t *testing.T) {
+	ensureInit(t)
+
+	header := "this is so wrong"
+	params := callParams([]string{"r1"}, "/v2", "svc", "GET")
+	authorized := true
+
+	if ok := PutAuthZDecision(header, params, authorized); ok {
+		t.Error("should refuse to put authz decision with invalid JWT")
+	}
+
+	got, found := LookupAuthZDecision(header, params)
+	if found {
+		t.Errorf("authz decision found: %v", got)
+	}
+}
+
+func TestNoCachedAuthZDecision(t *testing.T) {
+	ensureInit(t)
+
+	header := clientJSONPayload(expIn2050JWT)
+	params := callParams([]string{"r1"}, "/v2", "svc", "GET")
+
+	got, found := LookupAuthZDecision(header, params)
+	if found {
+		t.Errorf("authz decision found: %v", got)
+	}
+}

--- a/orionadapter/cache/rcache.go
+++ b/orionadapter/cache/rcache.go
@@ -1,0 +1,72 @@
+package cache
+
+import (
+	"math"
+	"time"
+
+	"github.com/dgraph-io/ristretto"
+)
+
+type cache interface {
+	// lookup value for key if any.
+	lookup(key string) (value interface{}, found bool)
+	// put entry with cost and keep for ttl secs.
+	put(key string, value interface{}, cost int64, ttlSeconds uint64) (ok bool)
+	// keep entry until next put or eviction.
+	keep(key string, value interface{}) (ok bool)
+}
+
+type rcache struct {
+	backend *ristretto.Cache
+}
+
+func newRCache(expectedEntries uint32, err error) (*rcache, error) {
+	if err != nil {
+		return nil, err
+	}
+	backend, err := ristretto.NewCache(&ristretto.Config{
+		// Number of keys to track frequency of.
+		NumCounters: int64(10 * expectedEntries),
+		// Maximum cost of cache (1GB).
+		MaxCost: 1 << 30,
+		// Number of keys per Get buffer.
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &rcache{backend}, nil
+}
+
+// NOTE. Cache tuning. While the above may be reasonable defaults, there's
+// no substitute for observing real prod workloads and then tune the cache
+// accordingly. We should provide config knobs to play with at some point.
+
+func (c *rcache) lookup(key string) (value interface{}, found bool) {
+	if c == nil {
+		return nil, false
+	}
+	return c.backend.Get(key)
+}
+
+func (c *rcache) put(key string, value interface{}, cost int64,
+	ttlSeconds uint64) (ok bool) {
+	if c == nil {
+		return false
+	}
+
+	if ttlSeconds > math.MaxInt32 {
+		ttlSeconds = math.MaxInt32 // time.Duration = int64 nanosec!
+	}
+	ttl := time.Duration(ttlSeconds) * time.Second
+
+	c.backend.Del(key)
+	return c.backend.SetWithTTL(key, value, cost, ttl)
+}
+
+func (c *rcache) keep(key string, value interface{}) (ok bool) {
+	return c.put(key, value, 1, 0)
+	// NOTE.
+	// * Cost. A cost of 0 means: use default cost function. So we set it to 1.
+	// * TTL. A TTL of 0 means: value never expires.
+}

--- a/orionadapter/cache/rcache_test.go
+++ b/orionadapter/cache/rcache_test.go
@@ -1,0 +1,142 @@
+package cache
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+)
+
+func newC(t *testing.T) *rcache {
+	c, err := newRCache(1, nil)
+	if err != nil {
+		t.Errorf("failed to instantiate cache: %v", err)
+	}
+	return c
+}
+
+func assertKeep(t *testing.T, c *rcache, key, val string) {
+	if ok := c.keep(key, val); !ok {
+		t.Errorf("didn't keep (%v, %v)", key, val)
+	}
+}
+
+func assertLookup(t *testing.T, c *rcache, key, expectedVal string) {
+	got, found := c.lookup(key)
+	if !found {
+		t.Errorf("found = false, got: %v", got)
+	}
+	if got != expectedVal {
+		t.Errorf("want: %v; got: %v", expectedVal, got)
+	}
+}
+
+func TestStoreAndRetrieve(t *testing.T) {
+	c := newC(t)
+
+	assertKeep(t, c, "k1", "v1")
+	assertKeep(t, c, "k2", "v2")
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	assertLookup(t, c, "k1", "v1")
+	assertLookup(t, c, "k2", "v2")
+}
+
+func TestReplace(t *testing.T) {
+	c := newC(t)
+
+	assertKeep(t, c, "k", "v1")
+	assertKeep(t, c, "k", "v2")
+
+	// wait for value to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	assertLookup(t, c, "k", "v2")
+}
+
+func TestExpiry(t *testing.T) {
+	c := newC(t)
+
+	var ttlSecs uint64 = 1
+	if ok := c.put("k", "v", 1, ttlSecs); !ok {
+		t.Error("shouldn't have put item")
+	}
+
+	// wait for value to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	assertLookup(t, c, "k", "v")
+
+	// wait for TTL to expire
+	time.Sleep(time.Duration(ttlSecs+1) * time.Second)
+
+	got, found := c.lookup("k")
+	if found {
+		t.Errorf("found = true, got: %v", got)
+	}
+}
+
+func TestDropTooExpensiveItem(t *testing.T) {
+	c := newC(t)
+	if ok := c.put("k", "v", math.MaxInt64, 10); !ok {
+		t.Error("should have accepted item")
+	}
+
+	// wait for value to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	got, found := c.lookup("k")
+	if found {
+		t.Errorf("found = true, got: %v", got)
+	}
+}
+
+func TestCanHandleTooLargeTTL(t *testing.T) {
+	c := newC(t)
+	c.put("k", "v", 1, math.MaxUint64)
+
+	// wait for value to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	assertLookup(t, c, "k", "v")
+}
+
+func TestLookupNonExistingEntry(t *testing.T) {
+	c := newC(t)
+	got, found := c.lookup("k")
+	if found {
+		t.Errorf("found, value: %v", got)
+	}
+}
+
+func TestNewRCacheDoNothingOnInputError(t *testing.T) {
+	previousErr := errors.New("prev err")
+	c, err := newRCache(1, previousErr)
+	if err != previousErr {
+		t.Errorf("instantiated cache: %v %v", err, c)
+	}
+}
+
+func TestLookupWhenNilRCache(t *testing.T) {
+	var c *rcache = nil
+	value, found := c.lookup("")
+	if found {
+		t.Errorf("found: %v", value)
+	}
+}
+
+func TestPutWhenNilRCache(t *testing.T) {
+	var c *rcache = nil
+	if ok := c.put("k", "v", 1, 10); ok {
+		t.Error("put value?!")
+	}
+}
+
+func TestKeepWhenNilRCache(t *testing.T) {
+	var c *rcache = nil
+	if ok := c.keep("k", "v"); ok {
+		t.Error("kept value?!")
+	}
+}

--- a/orionadapter/cache/rcache_test.go
+++ b/orionadapter/cache/rcache_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func newC(t *testing.T) *rcache {
+func newC(t *testing.T) cache {
 	c, err := newRCache(1, nil)
 	if err != nil {
 		t.Errorf("failed to instantiate cache: %v", err)
@@ -15,13 +15,13 @@ func newC(t *testing.T) *rcache {
 	return c
 }
 
-func assertKeep(t *testing.T, c *rcache, key, val string) {
+func assertKeep(t *testing.T, c cache, key, val string) {
 	if ok := c.keep(key, val); !ok {
 		t.Errorf("didn't keep (%v, %v)", key, val)
 	}
 }
 
-func assertLookup(t *testing.T, c *rcache, key, expectedVal string) {
+func assertLookup(t *testing.T, c cache, key, expectedVal string) {
 	got, found := c.lookup(key)
 	if !found {
 		t.Errorf("found = false, got: %v", got)

--- a/orionadapter/cache/store.go
+++ b/orionadapter/cache/store.go
@@ -1,0 +1,58 @@
+package cache
+
+// NOTE. Cache eviction. We use separate caches for each type of thing
+// we want to cache to avoid a situation where e.g. too many AuthZ entries
+// push a DAPS ID token out of the cache.
+type store struct {
+	authz  *rcache
+	daps   *rcache
+	config *rcache
+}
+
+func newStore() (*store, error) {
+	authz, err := newRCache(1e6, nil)
+	daps, err := newRCache(1, err)
+	config, err := newRCache(1, err)
+
+	return &store{
+		authz:  authz,
+		daps:   daps,
+		config: config,
+	}, err
+}
+
+type noopCache struct{}
+
+func (c *noopCache) lookup(key string) (value interface{}, found bool) {
+	return nil, false
+}
+
+func (c *noopCache) put(key string, value interface{}, cost int64,
+	ttlSeconds uint64) (ok bool) {
+	return false
+}
+
+func (c *noopCache) keep(key string, value interface{}) (ok bool) {
+	return false
+}
+
+func (s *store) AuthZ() cache {
+	if s == nil {
+		return &noopCache{}
+	}
+	return s.authz
+}
+
+func (s *store) Daps() cache {
+	if s == nil {
+		return &noopCache{}
+	}
+	return s.daps
+}
+
+func (s *store) Config() cache {
+	if s == nil {
+		return &noopCache{}
+	}
+	return s.config
+}

--- a/orionadapter/cache/store_test.go
+++ b/orionadapter/cache/store_test.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func assertNoop(t *testing.T, c cache) {
+	if v, found := c.lookup("k"); found {
+		t.Errorf("should've refused to lookup but got: %v", v)
+	}
+	if ok := c.keep("k", "v"); ok {
+		t.Error("should've refused to keep")
+	}
+	if ok := c.put("k", "v", 1, 1); ok {
+		t.Error("should've refused to put")
+	}
+}
+
+func newS(t *testing.T) *store {
+	s, err := newStore()
+	if err != nil {
+		t.Errorf("failed to instantiate store: %v", err)
+	}
+	return s
+}
+
+func TestNoopAuthZWhenNilStore(t *testing.T) {
+	var s *store = nil
+	assertNoop(t, s.AuthZ())
+}
+
+func TestAuthZStoreAndRetrieve(t *testing.T) {
+	s := newS(t)
+	assertKeep(t, s.AuthZ(), "k", "v")
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	assertLookup(t, s.AuthZ(), "k", "v")
+}
+
+func TestNoopDapsWhenNilStore(t *testing.T) {
+	var s *store = nil
+	assertNoop(t, s.Daps())
+}
+
+func TestDapsStoreAndRetrieve(t *testing.T) {
+	s := newS(t)
+	assertKeep(t, s.Daps(), "k", "v")
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	assertLookup(t, s.Daps(), "k", "v")
+}
+
+func TestNoopConfigWhenNilStore(t *testing.T) {
+	var s *store = nil
+	assertNoop(t, s.Config())
+}
+
+func TestConfigStoreAndRetrieve(t *testing.T) {
+	s := newS(t)
+	assertKeep(t, s.Config(), "k", "v")
+
+	// wait for values to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	assertLookup(t, s.Config(), "k", "v")
+}

--- a/orionadapter/endpoint/grpc.go
+++ b/orionadapter/endpoint/grpc.go
@@ -1,4 +1,4 @@
-package grpc
+package endpoint
 
 import (
 	"context"

--- a/orionadapter/endpoint/grpc.go
+++ b/orionadapter/endpoint/grpc.go
@@ -38,12 +38,6 @@ var _ od.HandleOrionadapterServiceServer = &OrionAdapter{}
 // call to our handler.
 func (s *OrionAdapter) HandleOrionadapter(ctx context.Context,
 	r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse, error) {
-	if cfg, err := handler.GetConfig(r); err == nil {
-		currentAdapterConfig = cfg
-	}
-	// TODO: get rid of above code once this gets sorted:
-	// - https://github.com/orchestracities/boost/issues/24
-
 	return handler.Authorize(r)
 }
 

--- a/orionadapter/endpoint/http.go
+++ b/orionadapter/endpoint/http.go
@@ -1,4 +1,4 @@
-package grpc
+package endpoint
 
 // TODO: stop gap solution to https://github.com/orchestracities/boost/issues/24
 // Sort out egress routing, then ditch this code and the Envoy filter.

--- a/orionadapter/endpoint/http.go
+++ b/orionadapter/endpoint/http.go
@@ -9,30 +9,27 @@ import (
 
 	ilog "istio.io/pkg/log"
 
-	"github.com/orchestracities/boost/orionadapter/codegen/config"
+	"github.com/orchestracities/boost/orionadapter/cache"
 	"github.com/orchestracities/boost/orionadapter/handler"
 )
 
-var currentAdapterConfig *config.Params = nil
-
-// TODO: concurrency!! currentAdapterConfig gets shared between gRPC
-// and HTTP servers!!
 // TODO: currentAdapterConfig will be nil until the first incoming
-// request for Orion hits the mesh---see server.HandleOrionadapter.
-// Hence any notification Orion will send before then, will have
-// no DAPS server token!!
+// request for Orion hits the mesh---see grpc.HandleOrionadapter.
+// Hence any notification Orion sends before then, will have no DAPS
+// server token!!
 
 func token(w http.ResponseWriter, req *http.Request) {
 	logRequest(req)
 
-	if currentAdapterConfig == nil {
+	currentAdapterConfig, found := cache.LookupAdapterConfig()
+	if !found {
 		msg := "http endpoint hasn't been initialized yet"
 		ilog.Errorf("%s", msg)
 		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 
-	serverToken, err := handler.GenerateToken(currentAdapterConfig)
+	serverToken, err := handler.GenerateProviderHeader(currentAdapterConfig)
 	if err != nil {
 		ilog.Errorf("error generating server token: %v", err)
 		http.Error(w, "error generating server token",

--- a/orionadapter/handler/auth.go
+++ b/orionadapter/handler/auth.go
@@ -44,13 +44,16 @@ func success(serverToken string) *od.HandleOrionadapterResponse {
 		Result: &iad.CheckResult{
 			Status:        status.OK,
 			ValidDuration: 0 * time.Second, // (*)
-			ValidUseCount: 0,               // (*)
+			ValidUseCount: 1,               // (*)
 		},
 		Output: &od.OutputMsg{ContextBrokerToken: serverToken},
 	}
 	// (*) Mixer caching. With those settings we're telling Mixer not to
 	// cache our responses. We do this since we've rolled out our own
-	// caching. Downside: Mixer will hit us every time a request comes in.
+	// caching. Downside: Mixer will hit us every time an HTTP request
+	// comes in. Actually for some obscure reason we get hit twice for
+	// each request, but thanks to caching the second call takes about
+	// 0.2ms on average. Peanuts, but annoying.
 }
 
 func permissionDeniedResponse(reason string) *od.HandleOrionadapterResponse {

--- a/orionadapter/handler/auth.go
+++ b/orionadapter/handler/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/orchestracities/boost/orionadapter/codegen/config"
 	od "github.com/orchestracities/boost/orionadapter/codegen/oriondata"
 	token "github.com/orchestracities/boost/orionadapter/sec"
+	"github.com/orchestracities/boost/orionadapter/sec/authz"
 )
 
 // Authorize tells the Mixer if it should reject the incoming request.
@@ -42,7 +43,18 @@ func Authorize(r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse,
 	}
 
 	if isAuthZEnabled(params) {
-
+		authorized, err := authorizeWithAuthZ(params, r.Instance, claims)
+		if err != nil {
+			ilog.Errorf("error authorizing with AuthZ server: %v\n", err)
+			return authzError(), nil
+		}
+		if !authorized {
+			ilog.Infof("AuthZ denied access to resource at: %v\n",
+				r.Instance.RequestPath)
+			return authzDeny(), nil
+		}
+		ilog.Infof("AuthZ authorized access to resource at: %v\n",
+			r.Instance.RequestPath)
 	}
 
 	return success(serverToken), nil
@@ -98,6 +110,34 @@ func buildDapsIDRequest(p *config.Params) (*token.DapsIDRequest, error) {
 	return r, nil
 }
 
+func authorizeWithAuthZ(p *config.Params, instance *od.InstanceMsg,
+	claims token.JwtPayload) (bool, error) {
+	serverURL, request, err := buildAuthZRequest(p, instance, claims)
+	if err != nil {
+		return false, err
+	}
+
+	client := authz.NewClient(serverURL)
+	return client.Authorize(request)
+}
+
+func buildAuthZRequest(p *config.Params, instance *od.InstanceMsg,
+	claims token.JwtPayload) (string, *authz.Request, error) {
+	url, err := getAuthZServerURL(p, nil)
+	rid, err := getAuthZResourceID(p, err)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return url, &authz.Request{
+		Roles:         claims.Scopes(),
+		ResourceID:    rid,
+		ResourcePath:  instance.RequestPath,
+		FiwareService: instance.FiwareService,
+		Action:        instance.RequestMethod,
+	}, nil
+}
+
 // response generation boilerplate
 
 func success(serverToken string) *od.HandleOrionadapterResponse {
@@ -139,4 +179,12 @@ func configError() *od.HandleOrionadapterResponse {
 
 func tokenGenError() *od.HandleOrionadapterResponse {
 	return adapterErrorResponse("context broker token could not be generated")
+}
+
+func authzError() *od.HandleOrionadapterResponse {
+	return adapterErrorResponse("failed to perform AuthZ check")
+}
+
+func authzDeny() *od.HandleOrionadapterResponse {
+	return permissionDeniedResponse("AuthZ denied authorization")
 }

--- a/orionadapter/handler/auth.go
+++ b/orionadapter/handler/auth.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/orchestracities/boost/orionadapter/codegen/config"
 	od "github.com/orchestracities/boost/orionadapter/codegen/oriondata"
-	token "github.com/orchestracities/boost/orionadapter/sec"
 	"github.com/orchestracities/boost/orionadapter/sec/authz"
+	"github.com/orchestracities/boost/orionadapter/sec/consumer"
+	"github.com/orchestracities/boost/orionadapter/sec/daps"
+	"github.com/orchestracities/boost/orionadapter/sec/jwt"
 )
 
 // Authorize tells the Mixer if it should reject the incoming request.
 // We go ahead with the request only if it contains a valid IDS-DTH
-// token.
+// token and, if enabled, AuthZ authorizes access to the target resource.
 func Authorize(r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse, error) {
 	ilog.Infof("auth request: %v\n", r.Instance)
 
@@ -60,32 +62,32 @@ func Authorize(r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse,
 	return success(serverToken), nil
 }
 
-func validateToken(pubKey string, headerValue string) (token.JwtPayload, error) {
-	jwt, err := token.ReadClientToken(headerValue)
+func validateToken(pubKey string, headerValue string) (jwt.Payload, error) {
+	jwtData, err := consumer.ReadToken(headerValue)
 	if err != nil {
 		return nil, err
 	}
-	return token.Validate(pubKey, jwt)
+	return jwt.Validate(pubKey, jwtData)
 }
 
 // GenerateToken gets a new ID token from DAPS, puts it into the configured
 // server header JSON object and then Base64 encodes the JSON object.
 func GenerateToken(p *config.Params) (string, error) {
-	daps, err := buildDapsIDRequest(p)
+	request, err := buildDapsIDRequest(p)
 	idTokenTemplate, err := getIDTokenJSONTemplate(p, err)
 	if err != nil {
 		return "", err
 	}
 
-	idToken, err := daps.IdentityToken()
+	idToken, err := request.IdentityToken()
 	if err != nil {
 		return "", err
 	}
 
-	return token.BuildServerHeader(idTokenTemplate, idToken)
+	return daps.BuildProviderHeader(idTokenTemplate, idToken)
 }
 
-func buildDapsIDRequest(p *config.Params) (*token.DapsIDRequest, error) {
+func buildDapsIDRequest(p *config.Params) (*daps.IDRequest, error) {
 	connectorID, err := getDapsConnectorID(p, nil)
 	connectorAudience, err := getDapsConnectorAudience(p, err)
 	secondsBeforeExpiry, err := getDapsSecondsBeforeExpiry(p, err)
@@ -98,7 +100,7 @@ func buildDapsIDRequest(p *config.Params) (*token.DapsIDRequest, error) {
 		return nil, err
 	}
 
-	r := &token.DapsIDRequest{
+	r := &daps.IDRequest{
 		ConnectorID:          connectorID,
 		ConnectorAudience:    connectorAudience,
 		SecondsBeforeExpiry:  secondsBeforeExpiry,
@@ -111,7 +113,7 @@ func buildDapsIDRequest(p *config.Params) (*token.DapsIDRequest, error) {
 }
 
 func authorizeWithAuthZ(p *config.Params, instance *od.InstanceMsg,
-	claims token.JwtPayload) (bool, error) {
+	claims jwt.Payload) (bool, error) {
 	serverURL, request, err := buildAuthZRequest(p, instance, claims)
 	if err != nil {
 		return false, err
@@ -124,7 +126,7 @@ func authorizeWithAuthZ(p *config.Params, instance *od.InstanceMsg,
 }
 
 func buildAuthZRequest(p *config.Params, instance *od.InstanceMsg,
-	claims token.JwtPayload) (string, *authz.Request, error) {
+	claims jwt.Payload) (string, *authz.Request, error) {
 	url, err := getAuthZServerURL(p, nil)
 	rid, err := getAuthZResourceID(p, err)
 	if err != nil {

--- a/orionadapter/handler/auth.go
+++ b/orionadapter/handler/auth.go
@@ -23,7 +23,7 @@ func Authorize(r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse,
 		return err, nil
 	}
 
-	providerHeader, err := generateProviderHeader(params)
+	providerHeader, err := GenerateProviderHeader(params)
 	if err != nil {
 		return err, nil
 	}

--- a/orionadapter/handler/auth.go
+++ b/orionadapter/handler/auth.go
@@ -17,7 +17,7 @@ import (
 // We go ahead with the request only if it contains a valid IDS-DTH
 // token.
 func Authorize(r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse, error) {
-	ilog.Infof("auth request: %v\n", *r)
+	ilog.Infof("auth request: %v\n", r.Instance)
 
 	params, err := GetConfig(r)
 	pubKeyPemRep, err := getIdsaPublicKey(params, err)
@@ -116,6 +116,8 @@ func authorizeWithAuthZ(p *config.Params, instance *od.InstanceMsg,
 	if err != nil {
 		return false, err
 	}
+
+	ilog.Infof("requesting permission from AuthZ: %+v\n", request)
 
 	client := authz.NewClient(serverURL)
 	return client.Authorize(request)

--- a/orionadapter/handler/auth.go
+++ b/orionadapter/handler/auth.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"time"
 
 	iad "istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/istio/mixer/pkg/status"
@@ -41,12 +42,15 @@ func Authorize(r *od.HandleOrionadapterRequest) (*od.HandleOrionadapterResponse,
 func success(serverToken string) *od.HandleOrionadapterResponse {
 	return &od.HandleOrionadapterResponse{
 		Result: &iad.CheckResult{
-			Status: status.OK,
-			// ValidDuration: 5 * time.Second
-			// i.e. caching? see Keyval
+			Status:        status.OK,
+			ValidDuration: 0 * time.Second, // (*)
+			ValidUseCount: 0,               // (*)
 		},
 		Output: &od.OutputMsg{ContextBrokerToken: serverToken},
 	}
+	// (*) Mixer caching. With those settings we're telling Mixer not to
+	// cache our responses. We do this since we've rolled out our own
+	// caching. Downside: Mixer will hit us every time a request comes in.
 }
 
 func permissionDeniedResponse(reason string) *od.HandleOrionadapterResponse {

--- a/orionadapter/handler/authztask.go
+++ b/orionadapter/handler/authztask.go
@@ -128,51 +128,51 @@ func authzDeny() *od.HandleOrionadapterResponse {
 //
 
 func (d *authZCallData) logMsgHeader() string {
-	h := `AuthZ\n  Request: %+v\n`
+	h := "AuthZ\n  Request: %+v\n"
 	return fmt.Sprintf(h, d.request)
 }
 
 func (d *authZCallData) logConfigError(err error) {
-	template := `  Error: can't configure call: %v\n`
+	template := "  Error: can't configure call: %v\n"
 	errorLine := fmt.Sprintf(template, err)
 	msg := d.logMsgHeader() + errorLine
 	ilog.Error(msg)
 }
 
 func (d *authZCallData) logCallError(err error) {
-	template := `  Error: AuthZ call failed: %v\n`
+	template := "  Error: AuthZ call failed: %v\n"
 	errorLine := fmt.Sprintf(template, err)
 	msg := d.logMsgHeader() + errorLine
 	ilog.Error(msg)
 }
 
 func (d *authZCallData) logPermitFromCache() {
-	decisionLine := `  Decision: Permit (cached)\n`
+	decisionLine := "  Decision: Permit (cached)\n"
 	msg := d.logMsgHeader() + decisionLine
 	ilog.Info(msg)
 }
 
 func (d *authZCallData) logDenyFromCache() {
-	decisionLine := `  Decision: Deny (cached)\n`
+	decisionLine := "  Decision: Deny (cached)\n"
 	msg := d.logMsgHeader() + decisionLine
 	ilog.Info(msg)
 }
 
 func cachingLine(decisionCached bool) string {
 	if decisionCached {
-		return `  Caching: decision saved to cache\n`
+		return "  Caching: decision saved to cache\n"
 	}
-	return `  Caching: decision not saved to cache\n`
+	return "  Caching: decision not saved to cache\n"
 }
 
 func (d *authZCallData) logDeny(decisionCached bool) {
-	decisionLine := `  Decision: Deny\n`
+	decisionLine := "  Decision: Deny\n"
 	msg := d.logMsgHeader() + decisionLine + cachingLine(decisionCached)
 	ilog.Info(msg)
 }
 
 func (d *authZCallData) logPermit(decisionCached bool) {
-	decisionLine := `  Decision: Permit\n`
+	decisionLine := "  Decision: Permit\n"
 	msg := d.logMsgHeader() + decisionLine + cachingLine(decisionCached)
 	ilog.Info(msg)
 }

--- a/orionadapter/handler/authztask.go
+++ b/orionadapter/handler/authztask.go
@@ -1,55 +1,96 @@
 package handler
 
 import (
+	"fmt"
+
 	ilog "istio.io/pkg/log"
 
+	"github.com/orchestracities/boost/orionadapter/cache"
 	"github.com/orchestracities/boost/orionadapter/codegen/config"
 	od "github.com/orchestracities/boost/orionadapter/codegen/oriondata"
 	"github.com/orchestracities/boost/orionadapter/sec/authz"
 	"github.com/orchestracities/boost/orionadapter/sec/jwt"
 )
 
+type authZCallData struct {
+	consumerHeader string
+	serverURL      string
+	request        *authz.Request
+}
+
+func newAuthZCall(params *config.Params, instance *od.InstanceMsg,
+	claims jwt.Payload) (*authZCallData, error) {
+	serverURL, request, err := buildAuthZRequest(params, instance, claims)
+	if err != nil {
+		return nil, err
+	}
+
+	return &authZCallData{
+		consumerHeader: instance.ClientToken,
+		serverURL:      serverURL,
+		request:        request,
+	}, nil
+}
+
+func (d *authZCallData) authZize() (authorized bool, e error) {
+	client := authz.NewClient(d.serverURL)
+	return client.Authorize(d.request)
+}
+
+func (d *authZCallData) cachedAuthZDecision() (authorized bool, found bool) {
+	return cache.LookupAuthZDecision(d.consumerHeader, d.request)
+}
+
+func (d *authZCallData) cacheAuthZDecision(authorized bool) (ok bool) {
+	return cache.PutAuthZDecision(d.consumerHeader, d.request, authorized)
+}
+
 func authorizeWithAuthZ(r *od.HandleOrionadapterRequest, params *config.Params,
 	claims jwt.Payload) (err *od.HandleOrionadapterResponse) {
 	if isAuthZEnabled(params) {
-		authorized, zErr := doAuthorizeWithAuthZ(params, r.Instance, claims)
-		if zErr != nil {
-			ilog.Errorf("error authorizing with AuthZ server: %v\n", zErr)
-			return authzError()
-		}
-
-		if !authorized {
-			ilog.Infof("AuthZ denied access to resource at: %v\n",
-				r.Instance.RequestPath)
-			return authzDeny()
-		}
-
-		ilog.Infof("AuthZ authorized access to resource at: %v\n",
-			r.Instance.RequestPath)
+		return doAuthorizeWithAuthZ(r, params, claims)
 	}
 	return nil
 }
 
-func doAuthorizeWithAuthZ(p *config.Params, instance *od.InstanceMsg,
-	claims jwt.Payload) (bool, error) {
-	serverURL, request, err := buildAuthZRequest(p, instance, claims)
-	if err != nil {
-		return false, err
+func doAuthorizeWithAuthZ(r *od.HandleOrionadapterRequest, params *config.Params,
+	claims jwt.Payload) (err *od.HandleOrionadapterResponse) {
+	z, zErr := newAuthZCall(params, r.Instance, claims)
+	if zErr != nil {
+		z.logConfigError(zErr)
+		return authzError()
 	}
 
-	ilog.Infof("requesting permission from AuthZ: %+v\n", request)
+	if authorized, found := z.cachedAuthZDecision(); found {
+		if authorized {
+			z.logPermitFromCache()
+			return nil
+		}
+		z.logDenyFromCache()
+		return authzDeny()
+	}
 
-	client := authz.NewClient(serverURL)
-	return client.Authorize(request)
+	authorized, zErr := z.authZize()
+	if zErr != nil {
+		z.logCallError(zErr)
+		return authzError()
+	}
+
+	decisionCached := z.cacheAuthZDecision(authorized)
+
+	if !authorized {
+		z.logDeny(decisionCached)
+		return authzDeny()
+	}
+
+	z.logPermit(decisionCached)
+	return nil
 }
 
 func buildAuthZRequest(p *config.Params, instance *od.InstanceMsg,
 	claims jwt.Payload) (string, *authz.Request, error) {
 	url, err := getAuthZServerURL(p, nil)
 	rid, err := getAuthZResourceID(p, err)
-	if err != nil {
-		return "", nil, err
-	}
 
 	return url, &authz.Request{
 		Roles:         claims.Scopes(),
@@ -57,8 +98,10 @@ func buildAuthZRequest(p *config.Params, instance *od.InstanceMsg,
 		ResourcePath:  instance.RequestPath,
 		FiwareService: instance.FiwareService,
 		Action:        instance.RequestMethod,
-	}, nil
+	}, err
 }
+
+// error response generation
 
 func authzError() *od.HandleOrionadapterResponse {
 	return adapterErrorResponse("failed to perform AuthZ check")
@@ -66,4 +109,70 @@ func authzError() *od.HandleOrionadapterResponse {
 
 func authzDeny() *od.HandleOrionadapterResponse {
 	return permissionDeniedResponse("AuthZ denied authorization")
+}
+
+// logging
+
+// message template (no errors)
+//
+// AuthZ
+//   Request: { ResourceID: ..., ..., Action: ... }
+//   Decision: Permit | Deny | Permit (cached) | Deny (cached)
+//   Caching: decision saved to cache | decision not saved to cache
+//
+// error message template
+//
+// AuthZ
+//   Request: { ResourceID: ..., ..., Action: ... }
+//   Error: ...
+//
+
+func (d *authZCallData) logMsgHeader() string {
+	h := `AuthZ\n  Request: %+v\n`
+	return fmt.Sprintf(h, d.request)
+}
+
+func (d *authZCallData) logConfigError(err error) {
+	template := `  Error: can't configure call: %v\n`
+	errorLine := fmt.Sprintf(template, err)
+	msg := d.logMsgHeader() + errorLine
+	ilog.Error(msg)
+}
+
+func (d *authZCallData) logCallError(err error) {
+	template := `  Error: AuthZ call failed: %v\n`
+	errorLine := fmt.Sprintf(template, err)
+	msg := d.logMsgHeader() + errorLine
+	ilog.Error(msg)
+}
+
+func (d *authZCallData) logPermitFromCache() {
+	decisionLine := `  Decision: Permit (cached)\n`
+	msg := d.logMsgHeader() + decisionLine
+	ilog.Info(msg)
+}
+
+func (d *authZCallData) logDenyFromCache() {
+	decisionLine := `  Decision: Deny (cached)\n`
+	msg := d.logMsgHeader() + decisionLine
+	ilog.Info(msg)
+}
+
+func cachingLine(decisionCached bool) string {
+	if decisionCached {
+		return `  Caching: decision saved to cache\n`
+	}
+	return `  Caching: decision not saved to cache\n`
+}
+
+func (d *authZCallData) logDeny(decisionCached bool) {
+	decisionLine := `  Decision: Deny\n`
+	msg := d.logMsgHeader() + decisionLine + cachingLine(decisionCached)
+	ilog.Info(msg)
+}
+
+func (d *authZCallData) logPermit(decisionCached bool) {
+	decisionLine := `  Decision: Permit\n`
+	msg := d.logMsgHeader() + decisionLine + cachingLine(decisionCached)
+	ilog.Info(msg)
 }

--- a/orionadapter/handler/authztask.go
+++ b/orionadapter/handler/authztask.go
@@ -1,0 +1,69 @@
+package handler
+
+import (
+	ilog "istio.io/pkg/log"
+
+	"github.com/orchestracities/boost/orionadapter/codegen/config"
+	od "github.com/orchestracities/boost/orionadapter/codegen/oriondata"
+	"github.com/orchestracities/boost/orionadapter/sec/authz"
+	"github.com/orchestracities/boost/orionadapter/sec/jwt"
+)
+
+func authorizeWithAuthZ(r *od.HandleOrionadapterRequest, params *config.Params,
+	claims jwt.Payload) (err *od.HandleOrionadapterResponse) {
+	if isAuthZEnabled(params) {
+		authorized, zErr := doAuthorizeWithAuthZ(params, r.Instance, claims)
+		if zErr != nil {
+			ilog.Errorf("error authorizing with AuthZ server: %v\n", zErr)
+			return authzError()
+		}
+
+		if !authorized {
+			ilog.Infof("AuthZ denied access to resource at: %v\n",
+				r.Instance.RequestPath)
+			return authzDeny()
+		}
+
+		ilog.Infof("AuthZ authorized access to resource at: %v\n",
+			r.Instance.RequestPath)
+	}
+	return nil
+}
+
+func doAuthorizeWithAuthZ(p *config.Params, instance *od.InstanceMsg,
+	claims jwt.Payload) (bool, error) {
+	serverURL, request, err := buildAuthZRequest(p, instance, claims)
+	if err != nil {
+		return false, err
+	}
+
+	ilog.Infof("requesting permission from AuthZ: %+v\n", request)
+
+	client := authz.NewClient(serverURL)
+	return client.Authorize(request)
+}
+
+func buildAuthZRequest(p *config.Params, instance *od.InstanceMsg,
+	claims jwt.Payload) (string, *authz.Request, error) {
+	url, err := getAuthZServerURL(p, nil)
+	rid, err := getAuthZResourceID(p, err)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return url, &authz.Request{
+		Roles:         claims.Scopes(),
+		ResourceID:    rid,
+		ResourcePath:  instance.RequestPath,
+		FiwareService: instance.FiwareService,
+		Action:        instance.RequestMethod,
+	}, nil
+}
+
+func authzError() *od.HandleOrionadapterResponse {
+	return adapterErrorResponse("failed to perform AuthZ check")
+}
+
+func authzDeny() *od.HandleOrionadapterResponse {
+	return permissionDeniedResponse("AuthZ denied authorization")
+}

--- a/orionadapter/handler/configtask.go
+++ b/orionadapter/handler/configtask.go
@@ -19,9 +19,9 @@ func extractConfig(r *od.HandleOrionadapterRequest) (
 	}
 
 	if ok := cache.PutAdapterConfig(params); ok {
-		ilog.Infof("cached latest adapter config: %v", params)
+		ilog.Info("cached latest adapter config\n")
 	} else {
-		ilog.Errorf("failed to cache latest adapter config: %v", params)
+		ilog.Error("failed to cache latest adapter config\n")
 	}
 	// TODO: get rid of above caching once this gets sorted:
 	// - https://github.com/orchestracities/boost/issues/24

--- a/orionadapter/handler/configtask.go
+++ b/orionadapter/handler/configtask.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	ilog "istio.io/pkg/log"
+
+	"github.com/orchestracities/boost/orionadapter/codegen/config"
+	od "github.com/orchestracities/boost/orionadapter/codegen/oriondata"
+)
+
+func extractConfig(r *od.HandleOrionadapterRequest) (
+	params *config.Params, err *od.HandleOrionadapterResponse) {
+	ilog.Infof("auth request: %v\n", r.Instance)
+
+	params, cErr := GetConfig(r)
+	if cErr != nil {
+		ilog.Errorf("can't read config from request: %v", cErr)
+		return nil, configError()
+	}
+
+	return params, nil
+}
+
+func configError() *od.HandleOrionadapterResponse {
+	return adapterErrorResponse("invalid configuration")
+}

--- a/orionadapter/handler/configtask.go
+++ b/orionadapter/handler/configtask.go
@@ -3,6 +3,7 @@ package handler
 import (
 	ilog "istio.io/pkg/log"
 
+	"github.com/orchestracities/boost/orionadapter/cache"
 	"github.com/orchestracities/boost/orionadapter/codegen/config"
 	od "github.com/orchestracities/boost/orionadapter/codegen/oriondata"
 )
@@ -16,6 +17,14 @@ func extractConfig(r *od.HandleOrionadapterRequest) (
 		ilog.Errorf("can't read config from request: %v", cErr)
 		return nil, configError()
 	}
+
+	if ok := cache.PutAdapterConfig(params); ok {
+		ilog.Infof("cached latest adapter config: %v", params)
+	} else {
+		ilog.Errorf("failed to cache latest adapter config: %v", params)
+	}
+	// TODO: get rid of above caching once this gets sorted:
+	// - https://github.com/orchestracities/boost/issues/24
 
 	return params, nil
 }

--- a/orionadapter/handler/consumervaltask.go
+++ b/orionadapter/handler/consumervaltask.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	ilog "istio.io/pkg/log"
+
+	"github.com/orchestracities/boost/orionadapter/codegen/config"
+	od "github.com/orchestracities/boost/orionadapter/codegen/oriondata"
+	"github.com/orchestracities/boost/orionadapter/sec/consumer"
+	"github.com/orchestracities/boost/orionadapter/sec/jwt"
+)
+
+func validateConsumer(r *od.HandleOrionadapterRequest, params *config.Params) (
+	claims jwt.Payload, err *od.HandleOrionadapterResponse) {
+	pubKeyPemRep, cErr := getIdsaPublicKey(params, nil)
+	if cErr != nil {
+		ilog.Infof("can't read configured consumer pub key: %v", cErr)
+		return nil, configError()
+	}
+
+	claims, vErr := validateToken(pubKeyPemRep, r.Instance.ClientToken)
+	if vErr != nil {
+		ilog.Infof("consumer JWT validation failed: %v", vErr)
+		return nil, invalidJWTError()
+	}
+
+	return claims, nil
+}
+
+func validateToken(pubKey string, headerValue string) (jwt.Payload, error) {
+	jwtData, err := consumer.ReadToken(headerValue)
+	if err != nil {
+		return nil, err
+	}
+	return jwt.Validate(pubKey, jwtData)
+}
+
+func invalidJWTError() *od.HandleOrionadapterResponse {
+	return permissionDeniedResponse("invalid consumer JWT data")
+}

--- a/orionadapter/handler/idtokentask.go
+++ b/orionadapter/handler/idtokentask.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	ilog "istio.io/pkg/log"
+
+	"github.com/orchestracities/boost/orionadapter/codegen/config"
+	od "github.com/orchestracities/boost/orionadapter/codegen/oriondata"
+	"github.com/orchestracities/boost/orionadapter/sec/daps"
+)
+
+func generateProviderHeader(params *config.Params) (
+	header string, err *od.HandleOrionadapterResponse) {
+	header, hErr := GenerateToken(params)
+	if hErr != nil {
+		ilog.Errorf("error generating provider header: %v\n", hErr)
+		return "", tokenGenError()
+	}
+
+	return header, nil
+}
+
+// GenerateToken gets a new ID token from DAPS, puts it into the configured
+// provider header JSON object and then Base64 encodes the JSON object.
+func GenerateToken(p *config.Params) (string, error) {
+	request, err := buildDapsIDRequest(p)
+	idTokenTemplate, err := getIDTokenJSONTemplate(p, err)
+	if err != nil {
+		return "", err
+	}
+
+	idToken, err := request.IdentityToken()
+	if err != nil {
+		return "", err
+	}
+
+	return daps.BuildProviderHeader(idTokenTemplate, idToken)
+}
+
+func buildDapsIDRequest(p *config.Params) (*daps.IDRequest, error) {
+	connectorID, err := getDapsConnectorID(p, nil)
+	connectorAudience, err := getDapsConnectorAudience(p, err)
+	secondsBeforeExpiry, err := getDapsSecondsBeforeExpiry(p, err)
+	privateKey, err := getDapsPrivateKey(p, err)
+	connectorCertificate, err := getDapsConnectorCertificate(p, err)
+	serverCertificate, err := getDapsServerCertificate(p, err)
+	serverHost, err := getDapsServerHost(p, err)
+
+	if err != nil {
+		return nil, err
+	}
+
+	r := &daps.IDRequest{
+		ConnectorID:          connectorID,
+		ConnectorAudience:    connectorAudience,
+		SecondsBeforeExpiry:  secondsBeforeExpiry,
+		PrivateKey:           privateKey,
+		ConnectorCertificate: connectorCertificate,
+		ServerCertificate:    serverCertificate,
+		ServerHost:           serverHost,
+	}
+	return r, nil
+}
+
+func tokenGenError() *od.HandleOrionadapterResponse {
+	return adapterErrorResponse("context broker token could not be generated")
+}

--- a/orionadapter/main.go
+++ b/orionadapter/main.go
@@ -5,10 +5,13 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/orchestracities/boost/orionadapter/cache"
 	grpc "github.com/orchestracities/boost/orionadapter/endpoint"
 )
 
 func main() {
+	initCache()
+
 	port := readPortArg()
 	s, err := grpc.NewOrionAdapter(port)
 	if err != nil {
@@ -41,4 +44,10 @@ func readPortArg() int {
 func runHTTP() {
 	port := os.Args[2] // TODO let it bomb out if no arg?!
 	go grpc.RunHTTPServerLoop(port)
+}
+
+func initCache() {
+	if err := cache.Init(); err != nil {
+		fmt.Printf("unable to initialize cache: %v", err)
+	}
 }

--- a/orionadapter/main.go
+++ b/orionadapter/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/orchestracities/boost/orionadapter/grpc"
+	grpc "github.com/orchestracities/boost/orionadapter/endpoint"
 )
 
 func main() {

--- a/orionadapter/sec/consumer/tokenrep.go
+++ b/orionadapter/sec/consumer/tokenrep.go
@@ -1,4 +1,4 @@
-package token
+package consumer
 
 import (
 	"encoding/base64"
@@ -6,22 +6,22 @@ import (
 	"fmt"
 )
 
-// ClientHeader holds the parts of the IDS client header we're interested in.
-type ClientHeader struct {
+// Header holds the bits of the IDS consumer header we're interested in.
+type Header struct {
 	SecurityToken struct {
 		TokenValue string `json:"tokenValue"`
 	} `json:"securityToken"`
 }
 
-func clientHeaderFromJSON(jsonData []byte) (*ClientHeader, error) {
-	var data ClientHeader
+func consumerHeaderFromJSON(jsonData []byte) (*Header, error) {
+	var data Header
 	err := json.Unmarshal(jsonData, &data)
 	return &data, err
 }
 
-func extractClientToken(idsHeaderValue string) (string, error) {
+func extractConsumerToken(idsHeaderValue string) (string, error) {
 	jsonData := []byte(idsHeaderValue)
-	header, err := clientHeaderFromJSON(jsonData)
+	header, err := consumerHeaderFromJSON(jsonData)
 	if err != nil {
 		return "", err
 	}
@@ -36,16 +36,16 @@ func jsonValueFromBase64(idsHeaderAttr string) (string, error) {
 	return string(decodedBytes), nil
 }
 
-// ReadClientToken reads the IDS client token from the IDS header.
+// ReadToken reads the IDS consumer JWT from the IDS header.
 // The input idsHeaderAttr is the Mixer attribute that captured the value of
 // the IDS header in the incoming HTTP request.
-// The output token is the actual client token contained in the IDS header.
-func ReadClientToken(idsHeaderAttr string) (token string, err error) {
+// The output token is the actual consumer token contained in the IDS header.
+func ReadToken(idsHeaderAttr string) (token string, err error) {
 	idsHeaderValue, err := jsonValueFromBase64(idsHeaderAttr)
 	if err != nil {
 		return "", headerDecodingError(err)
 	}
-	token, err = extractClientToken(idsHeaderValue)
+	token, err = extractConsumerToken(idsHeaderValue)
 	if err != nil {
 		return "", tokenExtractionError(err)
 	}
@@ -59,6 +59,6 @@ func headerDecodingError(cause error) error {
 }
 
 func tokenExtractionError(cause error) error {
-	return fmt.Errorf("error extracting client token from IDS header: %v",
+	return fmt.Errorf("error extracting consumer token from IDS header: %v",
 		cause)
 }

--- a/orionadapter/sec/consumer/tokenrep_test.go
+++ b/orionadapter/sec/consumer/tokenrep_test.go
@@ -1,4 +1,4 @@
-package token
+package consumer
 
 import (
 	"encoding/base64"
@@ -28,36 +28,36 @@ func clientJSONPayload(token string) string {
 	return fmt.Sprintf(clientJSONPayloadTemplate, token)
 }
 
-func assertReadClientToken(t *testing.T, jsonPayload string, want string) {
+func assertReadToken(t *testing.T, jsonPayload string, want string) {
 	idsHeaderAttr := toB64(jsonPayload)
-	if got, err := ReadClientToken(idsHeaderAttr); err != nil {
+	if got, err := ReadToken(idsHeaderAttr); err != nil {
 		t.Errorf("%s", err)
 	} else if got != want {
 		t.Errorf("wrong token. got: %s, want: %s", got, want)
 	}
 }
 
-func TestReadClientTokenWithToken(t *testing.T) {
+func TestReadConsumerHeaderWithToken(t *testing.T) {
 	want := "my.fat.jwt"
 	header := clientJSONPayload(want)
-	assertReadClientToken(t, header, want)
+	assertReadToken(t, header, want)
 }
 
-var readClientTokenWithoutToken = []struct {
+var readConsumerHeaderWithoutToken = []struct {
 	jsonValue string
 }{
 	{clientJSONPayload("")},
 	{`{"securityToken": {"tokenValue": null}}`},
 }
 
-func TestReadClientTokenWithoutToken(t *testing.T) {
+func TestReadConsumerHeaderWithoutToken(t *testing.T) {
 	want := ""
-	for _, k := range readClientTokenWithoutToken {
-		assertReadClientToken(t, k.jsonValue, want)
+	for _, k := range readConsumerHeaderWithoutToken {
+		assertReadToken(t, k.jsonValue, want)
 	}
 }
 
-var readClientTokenWithoutTokenValueField = []struct {
+var readConsumerHeaderWithoutTokenValueField = []struct {
 	jsonValue string
 }{
 	{`{ "securityToken": {} }`},
@@ -85,14 +85,14 @@ var readClientTokenWithoutTokenValueField = []struct {
 	},
 }
 
-func TestReadClientTokenWithoutTokenValueField(t *testing.T) {
+func TestReadConsumerHeaderWithoutTokenValueField(t *testing.T) {
 	want := ""
-	for _, k := range readClientTokenWithoutTokenValueField {
-		assertReadClientToken(t, k.jsonValue, want)
+	for _, k := range readConsumerHeaderWithoutTokenValueField {
+		assertReadToken(t, k.jsonValue, want)
 	}
 }
 
-var readClientTokenWithoutSecurityTokenField = []struct {
+var readConsumerHeaderWithoutSecurityTokenField = []struct {
 	jsonValue string
 }{
 	{`{}`},
@@ -115,44 +115,44 @@ var readClientTokenWithoutSecurityTokenField = []struct {
 	},
 }
 
-func TestReadClientTokenWithoutSecurityTokenField(t *testing.T) {
+func TestReadConsumerHeaderWithoutSecurityTokenField(t *testing.T) {
 	want := ""
-	for _, k := range readClientTokenWithoutSecurityTokenField {
-		assertReadClientToken(t, k.jsonValue, want)
+	for _, k := range readConsumerHeaderWithoutSecurityTokenField {
+		assertReadToken(t, k.jsonValue, want)
 	}
 }
 
-func TestReadClientTokenWithEmptyHeader(t *testing.T) {
+func TestReadEmptyConsumerHeader(t *testing.T) {
 	headerValue := ""
-	if _, err := ReadClientToken(headerValue); err == nil {
+	if _, err := ReadToken(headerValue); err == nil {
 		t.Error("should've returned a JSON parsing error.")
 	}
 }
 
-var readClientTokenWithMalformedHeaderValue = []struct {
+var readMalformedConsumerHeaderValue = []struct {
 	headerValue string
 }{
 	{`"`}, {`""`}, {`not base 64`}, {`{}`}, {clientJSONPayload("t.k.n")},
 }
 
-func TestReadClientTokenWithMalformedHeaderValue(t *testing.T) {
-	for _, k := range readClientTokenWithMalformedHeaderValue {
-		if _, err := ReadClientToken(k.headerValue); err == nil {
+func TestReadMalformedConsumerHeaderValue(t *testing.T) {
+	for _, k := range readMalformedConsumerHeaderValue {
+		if _, err := ReadToken(k.headerValue); err == nil {
 			t.Error("should've returned a Base 64 parsing error.")
 		}
 	}
 }
 
-var readClientTokenWithInvalidJSON = []struct {
+var readConsumerHeaderWithInvalidJSON = []struct {
 	jsonValue string
 }{
 	{`{`}, {`{{`}, {`{{}}`}, {`}`}, {`{in:valid}`},
 }
 
-func TestReadClientTokenWithInvalidJSON(t *testing.T) {
-	for _, k := range readClientTokenWithInvalidJSON {
+func TestReadConsumerHeaderWithInvalidJSON(t *testing.T) {
+	for _, k := range readConsumerHeaderWithInvalidJSON {
 		headerValue := toB64(k.jsonValue)
-		if _, err := ReadClientToken(headerValue); err == nil {
+		if _, err := ReadToken(headerValue); err == nil {
 			t.Error("should've returned a JSON parsing error.")
 		}
 	}

--- a/orionadapter/sec/daps/client.go
+++ b/orionadapter/sec/daps/client.go
@@ -1,4 +1,4 @@
-package token
+package daps
 
 import (
 	"crypto/tls"
@@ -22,14 +22,14 @@ func (u *baseURL) join(rest string) string {
 	return fmt.Sprintf("%s://%s%s", u.scheme, u.host, rest)
 }
 
-// DapsClient to talk to a DAPS server. Never instantiate one directly,
-// rather use NewDapsClient.
-type DapsClient struct {
+// Client to talk to a DAPS server. Never instantiate one directly,
+// rather use NewClient.
+type Client struct {
 	base *baseURL
 	conn *http.Client
 }
 
-// NewDapsClient builds an HTTP client to connect to the specified DAPS
+// NewClient builds an HTTP client to connect to the specified DAPS
 // host using mTLS. host can be either a plain host name or a host name
 // with a port number as in e.g. "whoopsie.dapsie.org:4433".
 // clientCert and clientPvtKey are, respectively, the certificate and
@@ -37,20 +37,20 @@ type DapsClient struct {
 // whereas serverCert is the DAPS server certificate the client should
 // use to authenticate the server. All of them are supposed to be in PEM
 // format.
-func NewDapsClient(host string, clientPvtKey string, clientCert string,
-	serverCert string) (*DapsClient, error) {
+func NewClient(host string, clientPvtKey string, clientCert string,
+	serverCert string) (*Client, error) {
 
 	clCert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientPvtKey))
 	if err != nil {
-		return &DapsClient{}, err
+		return &Client{}, err
 	}
 
 	svrCerts := x509.NewCertPool()
 	if !svrCerts.AppendCertsFromPEM([]byte(serverCert)) {
-		return &DapsClient{}, serverCertDecodingError()
+		return &Client{}, serverCertDecodingError()
 	}
 
-	return &DapsClient{
+	return &Client{
 		base: &baseURL{
 			scheme: "https",
 			host:   host,
@@ -147,7 +147,7 @@ func handleResponse(ensureContent bool,
 //
 // If the server replies with an error or a connection error occurs,
 // you get back that error and a nil ResponseBody.
-func (c *DapsClient) PostForm(urlPath string, data url.Values,
+func (c *Client) PostForm(urlPath string, data url.Values,
 	ensureResponseBody bool) (ResponseBody, error) {
 	url := c.base.join(urlPath)
 	r, err := c.conn.PostForm(url, data)

--- a/orionadapter/sec/daps/client_test.go
+++ b/orionadapter/sec/daps/client_test.go
@@ -1,4 +1,4 @@
-package token
+package daps
 
 import (
 	"fmt"
@@ -123,7 +123,7 @@ wSWFX8pQTNWseFTkRvJEShM=
 func TestBuildClientWithValidParams(t *testing.T) {
 	host, clPvtKey, clCert, srvCert :=
 		"whoopsie.dapsie", testCertPvtKey, testCert, testCert
-	_, err := NewDapsClient(host, clPvtKey, clCert, srvCert)
+	_, err := NewClient(host, clPvtKey, clCert, srvCert)
 	if err != nil {
 		t.Errorf("should've built a client struct: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestCantBuildClientWithoutClientPvtKey(t *testing.T) {
 	host, clCert, srvCert :=
 		"whoopsie.dapsie", testCert, testCert
 	for i, k := range cantBuildClientWithoutClientPvtKey {
-		_, err := NewDapsClient(host, k.pvtK, clCert, srvCert)
+		_, err := NewClient(host, k.pvtK, clCert, srvCert)
 		if err == nil {
 			t.Errorf("[%d] shouldn't have built a client struct: %v", i, err)
 		}
@@ -162,7 +162,7 @@ func TestCantBuildClientWithoutClientCert(t *testing.T) {
 	host, clPvtKey, srvCert :=
 		"whoopsie.dapsie", testCertPvtKey, testCert
 	for i, k := range cantBuildClientWithoutClientCert {
-		_, err := NewDapsClient(host, clPvtKey, k.cert, srvCert)
+		_, err := NewClient(host, clPvtKey, k.cert, srvCert)
 		if err == nil {
 			t.Errorf("[%d] shouldn't have built a client struct: %v", i, err)
 		}
@@ -182,7 +182,7 @@ func TestCantBuildClientWithoutServerCert(t *testing.T) {
 	host, clPvtKey, clCert :=
 		"whoopsie.dapsie", testCertPvtKey, testCert
 	for i, k := range cantBuildClientWithoutServerCert {
-		_, err := NewDapsClient(host, clPvtKey, clCert, k.cert)
+		_, err := NewClient(host, clPvtKey, clCert, k.cert)
 		if err == nil {
 			t.Errorf("[%d] shouldn't have built a client struct: %v", i, err)
 		}

--- a/orionadapter/sec/daps/idtoken_test.go
+++ b/orionadapter/sec/daps/idtoken_test.go
@@ -1,4 +1,4 @@
-package token
+package daps
 
 import (
 	"fmt"
@@ -6,29 +6,69 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jot "github.com/dgrijalva/jwt-go"
+
+	"github.com/orchestracities/boost/orionadapter/sec/jwt"
 )
 
-// NOTE. We'll use pvt/pub key pair declared in "tokenval_test.go".
+// RSA 256 keys generated on: https://jwt.io/
 
-func buildAndDecodeRequestTokenPayload(r *DapsIDRequest) (*jwt.StandardClaims, error) {
+const pubKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv
+vkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc
+aT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy
+tvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0
+e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb
+V6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9
+MwIDAQAB
+-----END PUBLIC KEY-----`
+
+const privateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWw
+kWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mr
+m/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEi
+NQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV
+3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2
+QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQABAoIBACiARq2wkltjtcjs
+kFvZ7w1JAORHbEufEO1Eu27zOIlqbgyAcAl7q+/1bip4Z/x1IVES84/yTaM8p0go
+amMhvgry/mS8vNi1BN2SAZEnb/7xSxbflb70bX9RHLJqKnp5GZe2jexw+wyXlwaM
++bclUCrh9e1ltH7IvUrRrQnFJfh+is1fRon9Co9Li0GwoN0x0byrrngU8Ak3Y6D9
+D8GjQA4Elm94ST3izJv8iCOLSDBmzsPsXfcCUZfmTfZ5DbUDMbMxRnSo3nQeoKGC
+0Lj9FkWcfmLcpGlSXTO+Ww1L7EGq+PT3NtRae1FZPwjddQ1/4V905kyQFLamAA5Y
+lSpE2wkCgYEAy1OPLQcZt4NQnQzPz2SBJqQN2P5u3vXl+zNVKP8w4eBv0vWuJJF+
+hkGNnSxXQrTkvDOIUddSKOzHHgSg4nY6K02ecyT0PPm/UZvtRpWrnBjcEVtHEJNp
+bU9pLD5iZ0J9sbzPU/LxPmuAP2Bs8JmTn6aFRspFrP7W0s1Nmk2jsm0CgYEAyH0X
++jpoqxj4efZfkUrg5GbSEhf+dZglf0tTOA5bVg8IYwtmNk/pniLG/zI7c+GlTc9B
+BwfMr59EzBq/eFMI7+LgXaVUsM/sS4Ry+yeK6SJx/otIMWtDfqxsLD8CPMCRvecC
+2Pip4uSgrl0MOebl9XKp57GoaUWRWRHqwV4Y6h8CgYAZhI4mh4qZtnhKjY4TKDjx
+QYufXSdLAi9v3FxmvchDwOgn4L+PRVdMwDNms2bsL0m5uPn104EzM6w1vzz1zwKz
+5pTpPI0OjgWN13Tq8+PKvm/4Ga2MjgOgPWQkslulO/oMcXbPwWC3hcRdr9tcQtn9
+Imf9n2spL/6EDFId+Hp/7QKBgAqlWdiXsWckdE1Fn91/NGHsc8syKvjjk1onDcw0
+NvVi5vcba9oGdElJX3e9mxqUKMrw7msJJv1MX8LWyMQC5L6YNYHDfbPF1q5L4i8j
+8mRex97UVokJQRRA452V2vCO6S5ETgpnad36de3MUxHgCOX3qL382Qx9/THVmbma
+3YfRAoGAUxL/Eu5yvMK8SAt/dJK6FedngcM3JEFNplmtLYVLWhkIlNRGDwkg3I5K
+y18Ae9n7dHVueyslrb6weq7dTkYDi3iOYRW8HRkIQh06wEdbxt0shTzAJvvCQfrB
+jg/3747WSsf/zBTcHihTRBdAv6OmdhV4/dD5YBfLAkLrd+mX7iE=
+-----END RSA PRIVATE KEY-----`
+
+func buildAndDecodeRequestTokenPayload(r *IDRequest) (*jot.StandardClaims, error) {
 	requestJWT, err := r.requestToken()
 	if err != nil {
-		return &jwt.StandardClaims{}, err
+		return &jot.StandardClaims{}, err
 	}
-	claims := &jwt.StandardClaims{}
-	_, err = jwt.ParseWithClaims(requestJWT, claims,
-		func(t *jwt.Token) (interface{}, error) {
-			return toRsaPubKey(pubKey)
+	claims := &jot.StandardClaims{}
+	_, err = jot.ParseWithClaims(requestJWT, claims,
+		func(t *jot.Token) (interface{}, error) {
+			return jwt.ToRsaPubKey(pubKey)
 		})
 	if err != nil {
-		return &jwt.StandardClaims{}, err
+		return &jot.StandardClaims{}, err
 	}
 	return claims, nil
 }
 
 func TestCanBuildValidRequestToken(t *testing.T) {
-	r := &DapsIDRequest{
+	r := &IDRequest{
 		SecondsBeforeExpiry: 10,
 		PrivateKey:          privateKey,
 	}
@@ -36,13 +76,13 @@ func TestCanBuildValidRequestToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("should've built a JWT: %v", err)
 	}
-	if _, err := Validate(pubKey, requestJWT); err != nil {
+	if _, err := jwt.Validate(pubKey, requestJWT); err != nil {
 		t.Errorf("should've built a valid JWT: %v", err)
 	}
 }
 
 func TestCantBuildRequestTokenWithoutPvtKey(t *testing.T) {
-	r := &DapsIDRequest{
+	r := &IDRequest{
 		SecondsBeforeExpiry: 10,
 	}
 	_, err := r.requestToken()
@@ -63,7 +103,7 @@ func assertClose(t *testing.T, a int64, b int64) {
 	}
 }
 
-var requestTokenExpClaim = []DapsIDRequest{
+var requestTokenExpClaim = []IDRequest{
 	{SecondsBeforeExpiry: 0}, {SecondsBeforeExpiry: 10},
 	{SecondsBeforeExpiry: 20}, {SecondsBeforeExpiry: 3600},
 }
@@ -81,7 +121,7 @@ func TestRequestTokenExpClaim(t *testing.T) {
 }
 
 func TestRequestTokenIssClaim(t *testing.T) {
-	r := &DapsIDRequest{PrivateKey: privateKey}
+	r := &IDRequest{PrivateKey: privateKey}
 	claims, err := buildAndDecodeRequestTokenPayload(r)
 	if err != nil {
 		t.Errorf("should've built a JWT: %v", err)
@@ -91,7 +131,7 @@ func TestRequestTokenIssClaim(t *testing.T) {
 }
 
 func TestRequestTokenNbfClaim(t *testing.T) {
-	r := &DapsIDRequest{PrivateKey: privateKey}
+	r := &IDRequest{PrivateKey: privateKey}
 	claims, err := buildAndDecodeRequestTokenPayload(r)
 	if err != nil {
 		t.Errorf("should've built a JWT: %v", err)
@@ -100,7 +140,7 @@ func TestRequestTokenNbfClaim(t *testing.T) {
 	assertClose(t, now, claims.NotBefore)
 }
 
-var requestTokenIssAndSubClaims = []DapsIDRequest{
+var requestTokenIssAndSubClaims = []IDRequest{
 	{}, {ConnectorID: ""}, {ConnectorID: " "}, {ConnectorID: "x"},
 	{ConnectorID: "2d80dc4e-7dfe-449c-8e3a-ce19b41685c3"},
 }
@@ -123,7 +163,7 @@ func TestRequestTokenIssAndSubClaims(t *testing.T) {
 	}
 }
 
-var requestTokenAudClaim = []DapsIDRequest{
+var requestTokenAudClaim = []IDRequest{
 	{}, {ConnectorAudience: ""}, {ConnectorAudience: " "},
 	{ConnectorAudience: "x"},
 	{ConnectorAudience: "https://consumerconnector.fiware.org"},
@@ -144,7 +184,7 @@ func TestRequestTokenAudClaim(t *testing.T) {
 }
 
 func TestIdentityTokenErrorWhenCantBuildClient(t *testing.T) {
-	r := &DapsIDRequest{}
+	r := &IDRequest{}
 	token, err := r.IdentityToken()
 	if err == nil {
 		t.Errorf("shouldn't have discarded unusable DAPS client: %s", token)

--- a/orionadapter/sec/daps/idtokenrep.go
+++ b/orionadapter/sec/daps/idtokenrep.go
@@ -1,15 +1,16 @@
-package token
+package daps
 
 import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
-// ServerHeader holds the IDS server header we generate.
-type ServerHeader struct {
+// ProviderHeader holds the IDS server header we generate.
+type ProviderHeader struct {
 	Type            string `json:"@type"`
 	ID              string `json:"id"`
 	Issued          string `json:"issued"`
@@ -22,16 +23,16 @@ type ServerHeader struct {
 	} `json:"securityToken"`
 }
 
-func fromConfig(idTokenJSONTemplate string) (*ServerHeader, error) {
-	out := &ServerHeader{}
+func fromConfig(idTokenJSONTemplate string) (*ProviderHeader, error) {
+	out := &ProviderHeader{}
 	data := []byte(idTokenJSONTemplate)
 	if err := json.Unmarshal(data, &out); err != nil {
-		return nil, malformedServerHeaderTemplateError(err)
+		return nil, malformedProviderHeaderTemplateError(err)
 	}
 	return out, nil
 }
 
-func populateServerHeader(config *ServerHeader, idToken string,
+func populateProviderHeader(config *ProviderHeader, idToken string,
 	err error) error {
 	if err != nil {
 		return err
@@ -49,36 +50,36 @@ func populateServerHeader(config *ServerHeader, idToken string,
 	return nil
 }
 
-func serializeServerHeader(h *ServerHeader, err error) (string, error) {
+func serializeProviderHeader(h *ProviderHeader, err error) (string, error) {
 	if err != nil {
 		return "", err
 	}
 
 	jsonRep, err := json.Marshal(h)
 	if err != nil {
-		return "", serverHeaderSerializationError(err)
+		return "", providerHeaderSerializationError(err)
 	}
 
 	b64rep := base64.StdEncoding.EncodeToString([]byte(jsonRep))
 	return b64rep, nil
 }
 
-// BuildServerHeader assembles the response header value containing
+// BuildProviderHeader assembles the response header value containing
 // the connector's ID token we got from DAPS.
-func BuildServerHeader(idTokenJSONTemplate string,
+func BuildProviderHeader(idTokenJSONTemplate string,
 	idToken string) (string, error) {
 	h, err := fromConfig(idTokenJSONTemplate)
-	err = populateServerHeader(h, idToken, err)
-	return serializeServerHeader(h, err)
+	err = populateProviderHeader(h, idToken, err)
+	return serializeProviderHeader(h, err)
 }
 
 // errors boilerplate
 
-func serverHeaderSerializationError(cause error) error {
+func providerHeaderSerializationError(cause error) error {
 	return fmt.Errorf("malformed ID token header: %v", cause)
 }
 
-func malformedServerHeaderTemplateError(cause error) error {
+func malformedProviderHeaderTemplateError(cause error) error {
 	return fmt.Errorf("malformed ID token JSON template: %v", cause)
 }
 

--- a/orionadapter/sec/daps/idtokenrep_test.go
+++ b/orionadapter/sec/daps/idtokenrep_test.go
@@ -1,4 +1,4 @@
-package token
+package daps
 
 import (
 	"encoding/base64"
@@ -22,7 +22,7 @@ const serverHeaderJSONTemplate string = `{
 
 func TestBuildServerHeader(t *testing.T) {
 	token := "my.fat.jwt"
-	b64rep, err := BuildServerHeader(serverHeaderJSONTemplate, token)
+	b64rep, err := BuildProviderHeader(serverHeaderJSONTemplate, token)
 	if err != nil {
 		t.Errorf("can't build header: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestBuildServerHeader(t *testing.T) {
 
 func TestBuildServerHeaderFromEmptyTemplate(t *testing.T) {
 	token := "my.fat.jwt"
-	b64rep, err := BuildServerHeader("{}", token)
+	b64rep, err := BuildProviderHeader("{}", token)
 	if err != nil {
 		t.Errorf("can't build header: %v", err)
 	}
@@ -73,7 +73,7 @@ var buildServerHeaderWithMalformedTemplate = []struct {
 func TestBuildServerHeaderWithMalformedTemplate(t *testing.T) {
 	token := "my.fat.jwt"
 	for _, k := range buildServerHeaderWithMalformedTemplate {
-		b64rep, err := BuildServerHeader(k.template, token)
+		b64rep, err := BuildProviderHeader(k.template, token)
 		if err == nil {
 			t.Errorf("shouldn't build header from malformed template: %s\n%s",
 				k.template, b64rep)
@@ -83,7 +83,7 @@ func TestBuildServerHeaderWithMalformedTemplate(t *testing.T) {
 
 func TestServerHeaderSerializationErrorBuilding(t *testing.T) {
 	cause := fmt.Errorf("whoa")
-	if err := serverHeaderSerializationError(cause); err == nil {
+	if err := providerHeaderSerializationError(cause); err == nil {
 		t.Errorf("should've build an error")
 	}
 }

--- a/orionadapter/sec/daps/integration_test.go
+++ b/orionadapter/sec/daps/integration_test.go
@@ -1,4 +1,4 @@
-package token
+package daps
 
 import (
 	"context"
@@ -63,7 +63,7 @@ func startServer(d *Dispatcher) (*http.Server, chan error) {
 func doIDInteractionWith(h MsgHandler) (
 	got string, clientErr, shutdownErr, svrErr error) {
 
-	daps := &DapsIDRequest{
+	daps := &IDRequest{
 		ConnectorID:          "4e16f007-d959-4eb2-b47d-78dd0c4eab0e",
 		ConnectorAudience:    "https://consumerconnector.fiware.org",
 		SecondsBeforeExpiry:  3600,

--- a/orionadapter/sec/jwt/payload.go
+++ b/orionadapter/sec/jwt/payload.go
@@ -1,26 +1,26 @@
-package token
+package jwt
 
 import (
 	"math"
 	"strconv"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jot "github.com/dgrijalva/jwt-go"
 )
 
-// JwtPayload holds JWT claims (token's payload block) in a map keyed by
+// Payload holds JWT claims (token's payload block) in a map keyed by
 // claim name.
-type JwtPayload map[string]interface{}
+type Payload map[string]interface{}
 
-func fromMapClaims(t *jwt.Token) JwtPayload {
+func fromMapClaims(t *jot.Token) Payload {
 	if t == nil {
-		return JwtPayload{}
+		return Payload{}
 	}
-	claims, ok := t.Claims.(jwt.MapClaims)
+	claims, ok := t.Claims.(jot.MapClaims)
 	if !ok {
-		return JwtPayload{}
+		return Payload{}
 	}
-	return (JwtPayload)(claims) // (*)
+	return (Payload)(claims) // (*)
 }
 
 // (*) Like JwtPayload, MapClaims has an underlying type of
@@ -29,24 +29,24 @@ func fromMapClaims(t *jwt.Token) JwtPayload {
 // FromRaw extracts the payload of the specified JWT without doing any
 // signature validation. If the input JWT is malformed, the returned
 // payload will be empty.
-func FromRaw(encodedToken string) JwtPayload {
-	p := new(jwt.Parser)
-	token, _, err := p.ParseUnverified(encodedToken, jwt.MapClaims{})
+func FromRaw(encodedToken string) Payload {
+	p := new(jot.Parser)
+	token, _, err := p.ParseUnverified(encodedToken, jot.MapClaims{})
 	if err != nil {
-		return JwtPayload{}
+		return Payload{}
 	}
 	return fromMapClaims(token)
 }
 
 // IsEmpty returns true just in case the payload contains no claims.
-func (p JwtPayload) IsEmpty() bool {
+func (p Payload) IsEmpty() bool {
 	return len(p) == 0
 }
 
 // Scopes returns the 'scopes' array in the JWT payload. If there's no
 // 'scopes' array or it isn't an array of strings, then return an empty
 // slice.
-func (p JwtPayload) Scopes() []string {
+func (p Payload) Scopes() []string {
 	switch scopes := p["scopes"].(type) {
 	case []interface{}:
 		return maybeStringSlice(scopes)
@@ -58,7 +58,7 @@ func (p JwtPayload) Scopes() []string {
 // ExpiresIn tells for how many seconds from now the token is still valid
 // by looking at the 'exp' standard claim. If there's no 'exp' field, then
 // return 0.
-func (p JwtPayload) ExpiresIn() uint64 {
+func (p Payload) ExpiresIn() uint64 {
 	now := toUint64(time.Now().Unix())
 	exp := p.ExpirationTime()
 	if exp <= now {
@@ -69,7 +69,7 @@ func (p JwtPayload) ExpiresIn() uint64 {
 
 // ExpirationTime reads the value of the 'exp' standard claim. If there's no
 // 'exp' field, then return 0.
-func (p JwtPayload) ExpirationTime() uint64 {
+func (p Payload) ExpirationTime() uint64 {
 	return toUint64(p["exp"])
 }
 

--- a/orionadapter/sec/jwt/payload_test.go
+++ b/orionadapter/sec/jwt/payload_test.go
@@ -1,4 +1,4 @@
-package token
+package jwt
 
 import (
 	"fmt"
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jot "github.com/dgrijalva/jwt-go"
 )
 
 func TestFromMapClaimsWithNil(t *testing.T) {
@@ -21,7 +21,7 @@ func TestFromMapClaimsWithNil(t *testing.T) {
 }
 
 func TestFromMapClaimsWithZeroValue(t *testing.T) {
-	token := &jwt.Token{}
+	token := &jot.Token{}
 	payload := fromMapClaims(token)
 	if payload == nil {
 		t.Errorf("want: empty payload; got: nil")
@@ -32,8 +32,8 @@ func TestFromMapClaimsWithZeroValue(t *testing.T) {
 }
 
 func TestFromMapClaimsWithIncompatibleType(t *testing.T) {
-	token := &jwt.Token{
-		Claims: &jwt.StandardClaims{
+	token := &jot.Token{
+		Claims: &jot.StandardClaims{
 			Subject: "foo",
 		},
 	}
@@ -47,8 +47,8 @@ func TestFromMapClaimsWithIncompatibleType(t *testing.T) {
 }
 
 func TestFromMapClaimsWithEntries(t *testing.T) {
-	token := &jwt.Token{
-		Claims: jwt.MapClaims{
+	token := &jot.Token{
+		Claims: jot.MapClaims{
 			"Subject": "foo",
 		},
 	}
@@ -65,7 +65,7 @@ func TestFromMapClaimsWithEntries(t *testing.T) {
 }
 
 func TestMissingScopes(t *testing.T) {
-	payload := JwtPayload{}
+	payload := Payload{}
 	got := payload.Scopes()
 	if got == nil {
 		t.Errorf("want: empty slice; got: nil")
@@ -76,7 +76,7 @@ func TestMissingScopes(t *testing.T) {
 }
 
 func TestScopesWithEmptyArray(t *testing.T) {
-	payload := JwtPayload{
+	payload := Payload{
 		"scopes": []interface{}{},
 	}
 	got := payload.Scopes()
@@ -89,7 +89,7 @@ func TestScopesWithEmptyArray(t *testing.T) {
 }
 
 func TestScopesWithIncompatibleType(t *testing.T) {
-	payload := JwtPayload{
+	payload := Payload{
 		"scopes": []int{},
 	}
 	got := payload.Scopes()
@@ -102,7 +102,7 @@ func TestScopesWithIncompatibleType(t *testing.T) {
 }
 
 func TestScopesWithSomeValues(t *testing.T) {
-	payload := JwtPayload{
+	payload := Payload{
 		"scopes": []interface{}{"a", "b"},
 	}
 	got := payload.Scopes()
@@ -120,7 +120,7 @@ func TestScopesWithSomeValues(t *testing.T) {
 	}
 }
 
-// jot is a JWT generated on jwt.io using keys in tokenval_test.go
+// jot is a JWT generated on jwt.io using keys in validation_test.go
 func extractScopesFromJwt(t *testing.T, jot string) []string {
 	payload, err := Validate(pubKey, jot)
 	if err != nil {
@@ -129,7 +129,7 @@ func extractScopesFromJwt(t *testing.T, jot string) []string {
 	return payload.Scopes()
 }
 
-// tokens generated on jwt.io with keys in tokenval_test.go
+// tokens generated on jwt.io with keys in validation_test.go
 var extractScopesFromJwtFixtures = []struct {
 	token string
 	want  []string
@@ -238,7 +238,7 @@ var expiresInFixtures = []struct {
 
 func TestExpiresIn(t *testing.T) {
 	for k, d := range expiresInFixtures {
-		payload := JwtPayload{
+		payload := Payload{
 			"exp": d.exp,
 		}
 		got := payload.ExpiresIn()

--- a/orionadapter/sec/jwt/rsa.go
+++ b/orionadapter/sec/jwt/rsa.go
@@ -1,0 +1,67 @@
+package jwt
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"time"
+
+	jot "github.com/dgrijalva/jwt-go"
+)
+
+// ToRsaPvtKey parses an RSA private key in PEM format.
+func ToRsaPvtKey(pemRep string) (*rsa.PrivateKey, error) {
+	keyBytes := []byte(pemRep)
+	key, err := jot.ParseRSAPrivateKeyFromPEM(keyBytes)
+	if err != nil {
+		return nil, invalidPvtKeyError(err)
+	}
+	return key, nil
+}
+
+// ToRsaPubKey parses an RSA public key in PEM format.
+func ToRsaPubKey(pemRep string) (*rsa.PublicKey, error) {
+	keyBytes := []byte(pemRep)
+	key, err := jot.ParseRSAPublicKeyFromPEM(keyBytes)
+	if err != nil {
+		return nil, invalidPubKeyError(err)
+	}
+	return key, nil
+}
+
+// MakeRS256SignedToken mints a JWT holding the specified standard claims
+// signed with the given RSA 256 private key in PEM format.
+func MakeRS256SignedToken(pvtKeyPemRep, subject, issuer, audience string,
+	secondsBeforeExpiry uint32) (string, error) {
+	key, err := ToRsaPvtKey(pvtKeyPemRep)
+	if err != nil {
+		return "", err
+	}
+	claims := standardClaims(subject, issuer, audience, secondsBeforeExpiry)
+	token := jot.NewWithClaims(jot.SigningMethodRS256, claims)
+	return token.SignedString(key)
+}
+
+func standardClaims(subject, issuer, audience string,
+	secondsBeforeExpiry uint32) *jot.StandardClaims {
+	now := time.Now().Unix()
+	return &jot.StandardClaims{
+		IssuedAt:  now,
+		NotBefore: now,
+		ExpiresAt: now + int64(secondsBeforeExpiry),
+		Subject:   subject,
+		Issuer:    issuer,
+		Audience:  audience,
+	}
+}
+
+// errors boilerplate
+
+func invalidPvtKeyError(cause error) *jot.ValidationError {
+	msg := fmt.Sprintf("invalid private key: %v", cause)
+	return jot.NewValidationError(msg, jot.ValidationErrorUnverifiable)
+}
+
+func invalidPubKeyError(cause error) *jot.ValidationError {
+	msg := fmt.Sprintf("invalid public key: %v", cause)
+	return jot.NewValidationError(msg, jot.ValidationErrorUnverifiable)
+}

--- a/orionadapter/sec/jwt/validation.go
+++ b/orionadapter/sec/jwt/validation.go
@@ -1,34 +1,20 @@
-package token
+package jwt
 
 import (
 	"crypto/rsa"
 	"fmt"
 
-	"github.com/dgrijalva/jwt-go"
+	jot "github.com/dgrijalva/jwt-go"
 )
 
-func unexpectedSigningMethodError(algo interface{}) *jwt.ValidationError {
+func unexpectedSigningMethodError(algo interface{}) *jot.ValidationError {
 	msg := fmt.Sprintf("unexpected signing method: %v", algo)
-	return jwt.NewValidationError(msg, jwt.ValidationErrorSignatureInvalid)
+	return jot.NewValidationError(msg, jot.ValidationErrorSignatureInvalid)
 }
 
-func invalidPubKeyError(cause error) *jwt.ValidationError {
-	msg := fmt.Sprintf("invalid public key: %v", cause)
-	return jwt.NewValidationError(msg, jwt.ValidationErrorUnverifiable)
-}
-
-func toRsaPubKey(pemRep string) (*rsa.PublicKey, error) {
-	keyBytes := []byte(pemRep)
-	key, err := jwt.ParseRSAPublicKeyFromPEM(keyBytes)
-	if err != nil {
-		return nil, invalidPubKeyError(err)
-	}
-	return key, nil
-}
-
-func ensureRsaSigning(key *rsa.PublicKey) jwt.Keyfunc {
-	return func(t *jwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+func ensureRsaSigning(key *rsa.PublicKey) jot.Keyfunc {
+	return func(t *jot.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jot.SigningMethodRSA); !ok {
 			return nil, unexpectedSigningMethodError(t.Header["alg"])
 		}
 		return key, nil
@@ -73,12 +59,12 @@ For a better explanation of the problem, see e.g.
 //    { alg: RS256 }.{ exp: 0 }.valid-rs256-signature
 // passes validation even though it expired at the beginning of the epoch!
 // Oh well.
-func Validate(pubKeyPemRep string, jwtData string) (JwtPayload, error) {
-	key, err := toRsaPubKey(pubKeyPemRep)
+func Validate(pubKeyPemRep string, jwtData string) (Payload, error) {
+	key, err := ToRsaPubKey(pubKeyPemRep)
 	if err != nil {
 		return nil, err
 	}
-	token, err := jwt.Parse(jwtData, ensureRsaSigning(key))
+	token, err := jot.Parse(jwtData, ensureRsaSigning(key))
 	if err != nil {
 		return nil, err
 	}

--- a/orionadapter/sec/jwt/validation_test.go
+++ b/orionadapter/sec/jwt/validation_test.go
@@ -1,4 +1,4 @@
-package token
+package jwt
 
 import (
 	"testing"

--- a/orionadapter/sec/jwtpayload.go
+++ b/orionadapter/sec/jwtpayload.go
@@ -1,6 +1,10 @@
 package token
 
 import (
+	"math"
+	"strconv"
+	"time"
+
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -9,6 +13,9 @@ import (
 type JwtPayload map[string]interface{}
 
 func fromMapClaims(t *jwt.Token) JwtPayload {
+	if t == nil {
+		return JwtPayload{}
+	}
 	claims, ok := t.Claims.(jwt.MapClaims)
 	if !ok {
 		return JwtPayload{}
@@ -18,6 +25,23 @@ func fromMapClaims(t *jwt.Token) JwtPayload {
 
 // (*) Like JwtPayload, MapClaims has an underlying type of
 // map[string]interface{}, so the cast is actually safe.
+
+// FromRaw extracts the payload of the specified JWT without doing any
+// signature validation. If the input JWT is malformed, the returned
+// payload will be empty.
+func FromRaw(encodedToken string) JwtPayload {
+	p := new(jwt.Parser)
+	token, _, err := p.ParseUnverified(encodedToken, jwt.MapClaims{})
+	if err != nil {
+		return JwtPayload{}
+	}
+	return fromMapClaims(token)
+}
+
+// IsEmpty returns true just in case the payload contains no claims.
+func (p JwtPayload) IsEmpty() bool {
+	return len(p) == 0
+}
 
 // Scopes returns the 'scopes' array in the JWT payload. If there's no
 // 'scopes' array or it isn't an array of strings, then return an empty
@@ -29,6 +53,85 @@ func (p JwtPayload) Scopes() []string {
 	default:
 		return []string{}
 	}
+}
+
+// ExpiresIn tells for how many seconds from now the token is still valid
+// by looking at the 'exp' standard claim. If there's no 'exp' field, then
+// return 0.
+func (p JwtPayload) ExpiresIn() uint64 {
+	now := toUint64(time.Now().Unix())
+	exp := p.ExpirationTime()
+	if exp <= now {
+		return 0
+	}
+	return exp - now
+}
+
+// ExpirationTime reads the value of the 'exp' standard claim. If there's no
+// 'exp' field, then return 0.
+func (p JwtPayload) ExpirationTime() uint64 {
+	return toUint64(p["exp"])
+}
+
+// conversion functions
+
+func toUint64(x interface{}) uint64 {
+	switch x.(type) {
+	case int8:
+		return intToUint64(int64(x.(int8)))
+	case int16:
+		return intToUint64(int64(x.(int16)))
+	case int32:
+		return intToUint64(int64(x.(int32)))
+	case int64:
+		return intToUint64(x.(int64))
+	case int:
+		return intToUint64(int64(x.(int)))
+	case uint8: // NB in Go, byte = uint8
+		return uint64(x.(uint8))
+	case uint16:
+		return uint64(x.(uint16))
+	case uint32:
+		return uint64(x.(uint32))
+	case uint64:
+		return x.(uint64)
+	case uint:
+		return uint64(x.(uint))
+	case float32:
+		return floatToUint64(float64(x.(float32)))
+	case float64:
+		return floatToUint64(x.(float64))
+	case string:
+		return stringToUint64(x.(string))
+	default:
+		return 0
+	}
+}
+
+func intToUint64(x int64) uint64 {
+	if x <= 0 {
+		return 0
+	}
+	return uint64(x)
+}
+
+func floatToUint64(x float64) uint64 {
+	y := math.Floor(x)
+	if y <= 0 {
+		return 0
+	}
+	if y >= math.MaxUint64 {
+		return math.MaxUint64
+	}
+	return uint64(y)
+}
+
+func stringToUint64(x string) uint64 {
+	y, err := strconv.ParseFloat(x, 64)
+	if err != nil {
+		return 0
+	}
+	return floatToUint64(y)
 }
 
 func maybeStringSlice(xs []interface{}) []string {

--- a/orionadapter/sec/jwtpayload.go
+++ b/orionadapter/sec/jwtpayload.go
@@ -24,9 +24,22 @@ func fromMapClaims(t *jwt.Token) JwtPayload {
 // slice.
 func (p JwtPayload) Scopes() []string {
 	switch scopes := p["scopes"].(type) {
-	case []string:
-		return ([]string)(scopes)
+	case []interface{}:
+		return maybeStringSlice(scopes)
 	default:
 		return []string{}
 	}
+}
+
+func maybeStringSlice(xs []interface{}) []string {
+	size := len(xs)
+	ys := make([]string, size, size)
+	for i, x := range xs {
+		if y, ok := x.(string); ok {
+			ys[i] = y
+		} else {
+			return []string{}
+		}
+	}
+	return ys
 }

--- a/orionadapter/sec/jwtpayload_test.go
+++ b/orionadapter/sec/jwtpayload_test.go
@@ -1,11 +1,24 @@
 package token
 
 import (
+	"fmt"
+	"math"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 )
+
+func TestFromMapClaimsWithNil(t *testing.T) {
+	payload := fromMapClaims(nil)
+	if payload == nil {
+		t.Errorf("want: empty payload; got: nil")
+	}
+	if size := len(payload); size != 0 {
+		t.Errorf("want: empty payload; got size: %v", size)
+	}
+}
 
 func TestFromMapClaimsWithZeroValue(t *testing.T) {
 	token := &jwt.Token{}
@@ -167,6 +180,149 @@ func TestExtractScopesFromJwt(t *testing.T) {
 	for k, d := range extractScopesFromJwtFixtures {
 		got := extractScopesFromJwt(t, d.token)
 		if !reflect.DeepEqual(d.want, got) {
+			t.Errorf("[%v] want: %v; got: %v", k, d.want, got)
+		}
+	}
+}
+
+var fromRawMalformedFixtures = []string{
+	"", ".", "..",
+	// derived from { alg: RS256 }.{ }.sig by chopping off part of payload
+	`eyJhbGciOiJSUzI1NiJ9.e.QHOtHczHK_bJrgqhXeZdE4xnCGh9zZhp67MHfRzHlUUe98eCup_uAEKh-2A8lCyg8sr1Q9dV2tSbB8vPecWPaB43BWKU00I7cf1jRo9Yy0nypQb3LhFMiXIMhX6ETOyOtMQu1dS694ecdPxMF1yw4rgqTtp_Sz-JfrasMLcxpBtT7USocnJHE_EkcQKVXeJ857JtkCKAzO4rkMli2sFnKckvoJMBoyrObZ_VFCVR5NGnOvSnLMqKrYaLxNHLDL_0Mxy_b8iKTiRAqyNce4tg8Evhqb3rPQcx9kMdwyv_1ggEVKQyiPWa3MkSBvBArgPghbJMcSJVMhtUO8M9BmNMyw`,
+	// same header & sig as above, but now payload: '{ in: valid! }'
+	`eyJhbGciOiJSUzI1NiJ9.eyBpbjogdmFsaWQhIH0.QHOtHczHK_bJrgqhXeZdE4xnCGh9zZhp67MHfRzHlUUe98eCup_uAEKh-2A8lCyg8sr1Q9dV2tSbB8vPecWPaB43BWKU00I7cf1jRo9Yy0nypQb3LhFMiXIMhX6ETOyOtMQu1dS694ecdPxMF1yw4rgqTtp_Sz-JfrasMLcxpBtT7USocnJHE_EkcQKVXeJ857JtkCKAzO4rkMli2sFnKckvoJMBoyrObZ_VFCVR5NGnOvSnLMqKrYaLxNHLDL_0Mxy_b8iKTiRAqyNce4tg8Evhqb3rPQcx9kMdwyv_1ggEVKQyiPWa3MkSBvBArgPghbJMcSJVMhtUO8M9BmNMyw`,
+}
+
+func TestFromRawMalformed(t *testing.T) {
+	for k, d := range fromRawMalformedFixtures {
+		got := FromRaw(d)
+		if !got.IsEmpty() {
+			t.Errorf("[%v] want: empty; got: %v", k, got)
+		}
+	}
+}
+
+var fromRawWithInvalidSignatureFixtures = []string{
+	// { alg: HS256 }.{ scopes = [a, b], exp: 123.1 }.sig
+	// sig is same as that for { alg: RS256 }.{} so it's not valid
+	`eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOlsiYSIsImIiXSwiZXhwIjoxMjMuMX0.QHOtHczHK_bJrgqhXeZdE4xnCGh9zZhp67MHfRzHlUUe98eCup_uAEKh-2A8lCyg8sr1Q9dV2tSbB8vPecWPaB43BWKU00I7cf1jRo9Yy0nypQb3LhFMiXIMhX6ETOyOtMQu1dS694ecdPxMF1yw4rgqTtp_Sz-JfrasMLcxpBtT7USocnJHE_EkcQKVXeJ857JtkCKAzO4rkMli2sFnKckvoJMBoyrObZ_VFCVR5NGnOvSnLMqKrYaLxNHLDL_0Mxy_b8iKTiRAqyNce4tg8Evhqb3rPQcx9kMdwyv_1ggEVKQyiPWa3MkSBvBArgPghbJMcSJVMhtUO8M9BmNMyw`,
+	// { alg: HS256 }.{ scopes = [a, b], exp: 123.1 }.junk_sig
+	`eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOlsiYSIsImIiXSwiZXhwIjoxMjMuMX0.junk_sig`,
+	// { alg: HS256 }.{ scopes = [a, b], exp: 123 }.junk_sig
+	`eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOlsiYSIsImIiXSwiZXhwIjoxMjN9.junk_sig`,
+}
+
+func TestFromRawWithInvalidSignature(t *testing.T) {
+	for k, d := range fromRawWithInvalidSignatureFixtures {
+		wantScopes := []string{"a", "b"}
+		wantExp := uint64(123)
+		got := FromRaw(d)
+		if !reflect.DeepEqual(wantScopes, got.Scopes()) {
+			t.Errorf("[%v] want scopes: %v; got: %v", k, wantScopes, got)
+		}
+		if wantExp != got.ExpirationTime() {
+			t.Errorf("[%v] want exp: %v; got: %v", k, wantExp, got)
+		}
+	}
+}
+
+var expiresInFixtures = []struct {
+	exp interface{}
+	lo  uint64
+	hi  uint64
+}{
+	{-12.3, 0, 0}, {0, 0, 0}, {time.Now().Unix(), 0, 0},
+	{float64(time.Now().Unix()) + 0.1, 0, 0},
+	{time.Now().Unix() + 10, 5, 10},
+}
+
+func TestExpiresIn(t *testing.T) {
+	for k, d := range expiresInFixtures {
+		payload := JwtPayload{
+			"exp": d.exp,
+		}
+		got := payload.ExpiresIn()
+		if got < d.lo || got > d.hi {
+			t.Errorf("[%v] want: ∈ [%v, %v]; got: %v", k, d.lo, d.hi, got)
+		}
+	}
+}
+
+// test conversion functions
+
+var intToUint64Fixtures = []struct {
+	input int64
+	want  uint64
+}{
+	{0, 0}, {-123, 0}, {math.MinInt64, 0}, {1, 1}, {123, 123},
+	{math.MaxInt64, math.MaxInt64},
+}
+
+func TestIntToUint64(t *testing.T) {
+	for k, d := range intToUint64Fixtures {
+		got := intToUint64(d.input)
+		if got != d.want {
+			t.Errorf("[%v] want: %v; got: %v", k, d.want, got)
+		}
+	}
+}
+
+var floatToUint64Fixtures = []struct {
+	input float64
+	want  uint64
+}{
+	{0, 0}, {-123, 0}, {math.MinInt64, 0}, {1, 1}, {123, 123},
+	{math.MaxUint64, math.MaxUint64},
+	{0.0, 0}, {-1.23, 0}, {1.1, 1}, {123.9, 123},
+}
+
+func TestFloatToUint64(t *testing.T) {
+	for k, d := range floatToUint64Fixtures {
+		var got uint64 = floatToUint64(d.input)
+		if got != d.want {
+			t.Errorf("[%v] want: %v; got: %v", k, d.want, got)
+		}
+	}
+}
+
+var stringToUint64Fixtures = []struct {
+	input string
+	want  uint64
+}{
+	{"", 0}, {"\n", 0}, {"junk", 0},
+	{"0", 0}, {"-123", 0},
+	{fmt.Sprintf("%d", int64(math.MinInt64)), 0},
+	{"1", 1}, {"123", 123},
+	{fmt.Sprintf("%d", uint64(math.MaxUint64)), math.MaxUint64},
+	{"0.0", 0}, {"-1.23", 0}, {"1.1", 1}, {"123.9", 123},
+}
+
+func TestStringToUint64(t *testing.T) {
+	for k, d := range stringToUint64Fixtures {
+		var got uint64 = stringToUint64(d.input)
+		if got != d.want {
+			t.Errorf("[%v] want: %v; got: %v", k, d.want, got)
+		}
+	}
+}
+
+var toUnit64Fixtures = []struct {
+	input interface{}
+	want  uint64
+}{
+	{int8(123), 123}, {int16(123), 123}, {int32(123), 123},
+	{int64(123), 123}, {int(123), 123},
+	{uint8(123), 123}, {uint16(123), 123}, {uint32(123), 123},
+	{uint64(123), 123}, {uint(123), 123},
+	{float32(123.9), 123}, {float64(123.9), 123},
+	{"123", 123},
+	{stringToUint64Fixtures, 0},
+}
+
+func TestToUint64(t *testing.T) {
+	for k, d := range toUnit64Fixtures {
+		var got uint64 = toUint64(d.input)
+		if got != d.want {
 			t.Errorf("[%v] want: %v; got: %v", k, d.want, got)
 		}
 	}

--- a/orionadapter/sec/jwtpayload_test.go
+++ b/orionadapter/sec/jwtpayload_test.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/dgrijalva/jwt-go"
@@ -63,7 +64,7 @@ func TestMissingScopes(t *testing.T) {
 
 func TestScopesWithEmptyArray(t *testing.T) {
 	payload := JwtPayload{
-		"scopes": []string{},
+		"scopes": []interface{}{},
 	}
 	got := payload.Scopes()
 	if got == nil {
@@ -89,7 +90,7 @@ func TestScopesWithIncompatibleType(t *testing.T) {
 
 func TestScopesWithSomeValues(t *testing.T) {
 	payload := JwtPayload{
-		"scopes": []string{"a", "b"},
+		"scopes": []interface{}{"a", "b"},
 	}
 	got := payload.Scopes()
 	if got == nil {
@@ -103,5 +104,70 @@ func TestScopesWithSomeValues(t *testing.T) {
 	}
 	if got[1] != "b" {
 		t.Errorf("want: b; got: %v", got[1])
+	}
+}
+
+// jot is a JWT generated on jwt.io using keys in tokenval_test.go
+func extractScopesFromJwt(t *testing.T, jot string) []string {
+	payload, err := Validate(pubKey, jot)
+	if err != nil {
+		t.Errorf("unexpected JWT validation error: %v", err)
+	}
+	return payload.Scopes()
+}
+
+// tokens generated on jwt.io with keys in tokenval_test.go
+var extractScopesFromJwtFixtures = []struct {
+	token string
+	want  []string
+}{
+	{
+		// { alg: RS256 }.{ }.sig
+		token: `eyJhbGciOiJSUzI1NiJ9.e30.QHOtHczHK_bJrgqhXeZdE4xnCGh9zZhp67MHfRzHlUUe98eCup_uAEKh-2A8lCyg8sr1Q9dV2tSbB8vPecWPaB43BWKU00I7cf1jRo9Yy0nypQb3LhFMiXIMhX6ETOyOtMQu1dS694ecdPxMF1yw4rgqTtp_Sz-JfrasMLcxpBtT7USocnJHE_EkcQKVXeJ857JtkCKAzO4rkMli2sFnKckvoJMBoyrObZ_VFCVR5NGnOvSnLMqKrYaLxNHLDL_0Mxy_b8iKTiRAqyNce4tg8Evhqb3rPQcx9kMdwyv_1ggEVKQyiPWa3MkSBvBArgPghbJMcSJVMhtUO8M9BmNMyw`,
+		want:  []string{},
+	},
+	{
+		// { alg: RS256 }.{ scopes: {} }.sig
+		token: `eyJhbGciOiJSUzI1NiJ9.eyJzY29wZXMiOnt9fQ.UgdhJ4RJzogOmHWnuo6lKNsES6CSVDubprKSuf2eFOoXNEcVJ4JZF-OXxqGQOnyv-_W4evOnI0oUiSyYLIKIHRyWkOf_Q1pAKOS4SkCDBjOTdmLJ0F-5KN4jH9jnWvQl7tRGltgSF_Ckm03Pjy_sHKP68NkEPSkUj1ElqXV7WD0KrYF7wxKc1H7ALLH54lH6i-SxDi10DxmZ3mPhDg1ITu1HF3GqhQupAYEP1tN99HEhG6SyhTOtgRzOJzowAGv-5Y5MTAtukDc9q4IinNtPxAnRuI1-4E01hhQl-5bKKpwjq-u6wDNelm8P06K-fnp2STWIpdWR22oYyw0189FnZw`,
+		want:  []string{},
+	},
+	{
+		// { alg: RS256 }.{ scopes: { x: "a" } }.sig
+		token: `eyJhbGciOiJSUzI1NiJ9.eyJzY29wZXMiOnsieCI6ImEifX0.heSSwk-3KAfMsq-pyE5CBecwBBfPsqnWCkFVKFy9LSmjp26Dg-pCEItr5u2LFuYziJ1gQ73bpfIjmMWg2au6gEhcVRkz7_Ao36WYLWl8Q-WqaysTEajJs97Mx3voiCThVdC-2i6MjESOQZSFGYERGRXuXZbZaFahL3_xJW1jn0T4LHqJF_eNjCkkQCTNg-P3hfh59DB0Pou4Rl8xzJ4ylb0rwQAYCpUJN-i9Q6lxGLpWBrOYc3vGM3v2Pk_nYY3CHkEPRfxlO4fTyxCUi_vjOI7u7FEOpQgCoM2zOxcrbsfe6Ecs-x-A2RMzE_x5VDUndauAjclI4uqdUZBoG6A7qQ`,
+		want:  []string{},
+	},
+	{
+		// { alg: RS256 }.{ scopes: [ 1 ] } }.sig
+		token: `eyJhbGciOiJSUzI1NiJ9.eyJzY29wZXMiOlsxXX0.B7TInAaydbOBAFtmu2onpNGRl7uUejqMoCfobk0KJURC664r6RBrIzylBzorxhZNiJD6PSytJKxRwUd9TU9pHt7RZMNkdiSjpOmjeGtgcmHEt42D4K31TISonjetb2WFvspX74ELWxwE1dOv9iA2_0bua1layJJsA5zMHVrbl1bWWcsYUWYayXhiGvokVCJM-Uj3UM1235cogGwNnS878nGpACIz-6Zy-xjvOmag3N8kzeF6fxuE1AWOpyAS_eKfWycchkcv0wdJno72XjPq2bF0SE8nt71i7zPZ3XfK-s4Cf2OC5dE8MqO8hqyDWtF8SnMpbFgCwD_BoXLFsAnYCg`,
+		want:  []string{},
+	},
+	{
+		// { alg: RS256 }.{ scopes: [ "a", { x: 1 } ] } }.sig
+		token: `eyJhbGciOiJSUzI1NiJ9.eyJzY29wZXMiOlsiYSIseyJ4IjoxfV19.Sckms1Vgmba6oKj-l5zlBK2jJIY3Btilvk7oGV4WcnIrrHFrhJaPBigkhs15f9IYtuJW30RaJLt5VMB0J5jMUZPfNRR39WVGMOfTQlBsw7NWnYlxnP-NEa9bUdxfqd1NLeNmVvs563TOiRdXjr4ZImrB0V-q-c0RuaBbse5RAt2YXJu_BIq7nSY1yLO8o2gn8LdvJ04h24Cr_OO_XaGcGMUK84FMzn65iqtb-rQsrIsIIYWzT5gp2hOX-cw8ysc5vlUM6Hl71GfincNgTh5JKRVyxdvGQroIfHVLiw5Lcf3G3JoiAPVRsOhDbW4H9aRu6q1NmlUfkm0A-KNnuXdZUg`,
+		want:  []string{},
+	},
+	{
+		// { alg: RS256 }.{ scopes: [] }.sig
+		token: `eyJhbGciOiJSUzI1NiJ9.eyJzY29wZXMiOltdfQ.NDoKBnYgN68veFdWH05nReGKt8g6eNNo0jD2xHAImWSPvyKzK1OtFOH_kDMGomenRQe8bzqxVngVa-Fh7FxcYwFDwRULGkUH617UVfx9FW5Bw9dby9Lfx4XdLs9zUSt6nvhJ0nohCYORM9Gvs2DDY-V8i_upaeE5FvLfYRTbTyBl1fmPaxWvAqNr_CGTpF2JUSaqUiE0pdvyocPrbcaZyq8tB26Gh6YWqV515bNvQCMBkW-fedW-2JBOjqGiwChom1q1qlGN5d9lw6DsBCf9nfWMdubR3QIbShSAwVdLUP-6lJNxKMS-PbcAgrWv6Ev14Yu1fQJwJ6omSNy8reEFHg`,
+		want:  []string{},
+	},
+	{
+		// { alg: RS256 }.{ scopes: [ "a" ] }.sig
+		token: `eyJhbGciOiJSUzI1NiJ9.eyJzY29wZXMiOlsiYSJdfQ.Ic1Krq6yc8Tt516zhbRus6bJh0CDXj5tQZgph_0CdW4zc9dtMOYOdVr9DJ3mv-J7kG7-pX7QZiDTcAK0vrnRfD98cB7aonRc97_TjvyO3H9HrdEabuxmfnnGgjyKQ4LCO-TCMj-mtbmmAVUyJ3gXpFuDLtOF0WvK2XIbVjTbtRpkEFEME0LqhpkVxIi_2I5V4oHF7yRLs_CMtxu1IZUY-ko9QLxr9aGWGM-AmG4yW1UcR93UBS5Mve2lY4-VDNrZYtTeTQ51vMbjxcQXcPH_ofQkoVl_TIGZNY33OvcHF0hUKCGPJWlsAIWHYBPV5iTW3RDqeci6owrZCmqI8RbJMw`,
+		want:  []string{"a"},
+	},
+	{
+		// { alg: RS256 }.{ scopes: [ "a", "b" ] }.sig
+		token: `eyJhbGciOiJSUzI1NiJ9.eyJzY29wZXMiOlsiYSIsImIiXX0.AZy5YuwcZ0tR3vLCsyr8KuMA7H2vESWFM3QgBHRPxoXdrqtJm40n5ZoN01aY12xSnyVyhXJ7txNX7zaMH3Gjq7Q-1_RQCCHjYzGoxheQhBJk7l2KNXmnMRgHDfO41nEHpJ8JoGc1wc_e81Agl7kJ0jzt-_6bFiBkWx6AstJaFuoe8ZSqbE5w89k-99B_0Hnb6tBg_gohhma2w3lYS2oFR9q0vhTzLDy6y7GF3BhjWqcvN2MDhRqhWUin7tLpOgJ2Uc9W0zEjGOAcOXnWW-ljy5cBc0g4TRHJk_EWreolhNMlNKrpJOoL_Qwf_pChoZynQ0pBiIsTk8RqkeuSULbQug`,
+		want:  []string{"a", "b"},
+	},
+}
+
+func TestExtractScopesFromJwt(t *testing.T) {
+	for k, d := range extractScopesFromJwtFixtures {
+		got := extractScopesFromJwt(t, d.token)
+		if !reflect.DeepEqual(d.want, got) {
+			t.Errorf("[%v] want: %v; got: %v", k, d.want, got)
+		}
 	}
 }

--- a/scripts/send-token.sh
+++ b/scripts/send-token.sh
@@ -18,7 +18,8 @@ source "${ROOTDIR}/scripts/env.sh"
 
 HEADERARG=$(sh "${ROOTDIR}/scripts/idsa-header-value.sh" "${TOKENARG}")
 
-"${OUTBINDIR}/mixc" check -s destination.service="svc.cluster.local" \
+"${OUTBINDIR}/mixc" check \
+    -s destination.service="svc.cluster.local",request.method=GET,request.path="/" \
     --stringmap_attributes "request.headers=header:${HEADERARG}"
 
 # NOTE. IDSA header name. Yep, it's aptly called "header" :-)

--- a/yamster/src/Mesh/Config/Adapter.hs
+++ b/yamster/src/Mesh/Config/Adapter.hs
@@ -21,6 +21,9 @@ import Mesh.Util.K8s (ServiceSpec(..), Port(..), chooseServiceName, serviceFqn)
 idsSecHeaderName ∷ String
 idsSecHeaderName = "header"
 
+fiwareServiceHeaderName ∷ String
+fiwareServiceHeaderName = "fiware-service"
+
 
 -- collect data to generate orionadapter Istio resources.
 data OrionAdapterSpec = OrionAdapterSpec
@@ -75,11 +78,20 @@ instance AdapterSpec OrionAdapterSpec where
       "private_key" =: connectorPrivateKey pki
       "connector_certificate" =: connectorCertificate pki
       "server_certificate" =: dapsServerCertificate pki
+    "authz" =: do
+      "enabled" =: False
+      "server_url" =: "http://authzforceingress.appstorecontainerns.46.17.108.63.xip.io/authzforce-ce/domains/CYYY_V2IEeqMJKbegCuurA/pdp"
+      "resource_id" =: "b3a4a7d2-ce61-471f-b05d-fb82452ae686"
 
   templateName = const "oriondata"
 
   instanceParams _ = do
-    "client_token" =: ("request.headers[\"" ++ idsSecHeaderName ++ "\"]")
+    "request_method" =: "request.method"
+    "request_path" =: "request.path"
+    "fiware_service" =: header fiwareServiceHeaderName
+    "client_token" =: header idsSecHeaderName
+    where
+      header name = "request.headers[\"" ++ name ++ "\"] | \"\""
 
   handlerResponseName = const "adapter_response"
 


### PR DESCRIPTION
This PR implements caching of security operations as outlined in #9.
Notice this PR also brings to `master` unrelated (but welcome!) code changes that got merged into `dev`---see PR #33.

### Overview
A new component (`orionadapter/cache` package) provides the caching functionality to the adapter through a typed map-like interface that shields the rest of the code from the inner details and whether the backing cache is in memory or distributed. At the moment, we piggyback on an in-memory backing store, [Ristretto][ristretto], that comes with sophisticated caching policies, high-performance concurrent access and correctness guarantees under concurrent usage. We cache DAPS ID tokens, AuthZ decisions and adapter configuration each in its own backing store to cater for different usage patterns---e.g. we have different cache eviction policies to avoid a situation where too many AuthZ entries push a DAPS ID token out of the cache. The caches got tuned quite a bit and the default settings should cater for most scenarios but there's no substitute for observing real prod workloads and then tune the cache accordingly. We should provide config knobs to play with at some point. Below is a sum up of each cache's features.

### DAPS ID cache
After getting a provider ID token from DAPS, we keep it until it expires so won't call again the DAPS server until then. Expiry is that specified by the `exp` field of the DAPS JWT. If `exp` is in the past or there's no `exp` field, we won't cache the token. Notice DAPS returns a JSON object with the actual JWT and an additional `expires_in` JSON field. We never consider `expires_in` since it isn't signed data so even if we got an `expires_in` with a time in the future but no `exp` in the future, then we still wouldn't cache the token.

### AuthZ decision cache
We identify AuthZ calls by consumer JTW and all other relevant inputs (HTTP method/path, FiWare service, etc.) so that two calls are equivalent just in case they have the same inputs. After getting an AuthZ decision for a set of inputs, we cache the authorisation decision until the input consumer JWT expires. Expiry is that specified by the JWT `exp` field. If `exp` is in the past or there's no `exp` field, we won't cache the decision. If another HTTP request comes in which requires an equivalent AuthZ call, we'll use the cached decision unless it has expired, in which case we'll call AuthZ again. Cache growth is capped at 1GB to avoid the adapter becoming a memory hog and admission/eviction policies try to maximise hit ratio.

### Adapter configuration cache
We cache adapter configuration too. This is only needed to support our stopgap solution (#25) to #24 and we can ditch it as soon as a better option becomes available. This cache is the simplest so far: it only stores one item at a time (the adapter config) until a fresher config becomes available at which point the old config gets replaced with the new. This happens every time the Mixer calls the adapter---the gRPC request contains the latest config. 



[ristretto]: https://github.com/dgraph-io/ristretto
