### PR TITLE
The Orion sidecar tale of woe

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,16 @@ After installing Minikube, download the Istio release and install the demo
 profile. Here's the short version, assuming you've already installed Minikube:
 
     $ cd ~
+
+    # Start Minikube.
+
     $ minikube start --memory=16384 --cpus=4
     # Try --memory=4096 if you don't have that much RAM, it worked for us :-)
     $ kubectl config use-context minikube
+
+    # Download and install Istio 1.4.2.
+
+    $ export ISTIO_VERSION=1.4.2
     $ curl -L https://istio.io/downloadIstio | sh -
     $ cd istio-*
     $ export PATH="${PWD}/bin:${PATH}"
@@ -118,6 +125,12 @@ Long version:
 - https://istio.io/docs/setup/getting-started/
 - https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection
 - https://istio.io/docs/tasks/policy-enforcement/enabling-policy/
+
+**Note**. *Istio version*. Version `1.4.2` is the safest to use since
+we've compiled and tested the adapter's gRPC interface against this
+version. We also tested extensively with version `1.4.0` and `1.4.3`.
+In principle what's documented in this README should work with any
+`1.4.*` version and, barring minor adjustments, with `1.5.*` too.
 
 **Note**. *Policy Enforcement*. The docs say the `demo` profile should enable
 it (i.e. set `disablePolicyChecks` to `false`) but it doesn't nor does it

--- a/deployment/egress_filter.yaml
+++ b/deployment/egress_filter.yaml
@@ -36,4 +36,46 @@ spec:
         type: STRICT_DNS
   workloadSelector:
     labels:
+      app: orion
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: "httpbin-egress-filter"
+  namespace: default
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+        portNumber: 80
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        config:
+          inlineCode: "\n    function envoy_on_request(request_handle)\n        local headers, body = request_handle:httpCall(\n            \"lua_cluster\",\n            { [\":method\"] = \"GET\",\n              [\":path\"] = \"/\",\n              [\":authority\"] = \"lua_cluster\"\n            },\n            \"\",\n            5000)\n        request_handle:headers():add(\"header\", body)\n    end\n"
+        name: envoy.lua
+  - applyTo: CLUSTER
+    patch:
+      operation: ADD
+      value:
+        connect_timeout: 5.5s
+        hosts:
+        - socket_address:
+            address: "orionadapterservice.istio-system"
+            port_value: 54321
+            protocol: TCP
+        lb_policy: ROUND_ROBIN
+        name: lua_cluster
+        type: STRICT_DNS
+  workloadSelector:
+    labels:
       app: httpbin

--- a/deployment/orion_service.yaml
+++ b/deployment/orion_service.yaml
@@ -34,14 +34,9 @@ spec:
     spec:
       containers:
       - command:
-        - /usr/bin/contextBroker
-        - "-fg"
-        - "-multiservice"
-        - "-ngsiv1Autocast"
-        - "-dbhost"
-        - mongodb
-        - "-logLevel"
-        - DEBUG
+        - bash
+        - "-c"
+        - "sleep 4; exec /usr/bin/contextBroker -fg -multiservice -ngsiv1Autocast -dbhost mongodb -logLevel DEBUG"
         image: "fiware/orion:2.2.0"
         imagePullPolicy: IfNotPresent
         name: orion

--- a/deployment/orion_service.yaml
+++ b/deployment/orion_service.yaml
@@ -36,7 +36,7 @@ spec:
       - command:
         - bash
         - "-c"
-        - "sleep 4; exec /usr/bin/contextBroker -fg -multiservice -ngsiv1Autocast -dbhost mongodb -logLevel DEBUG"
+        - "sleep 10; exec /usr/bin/contextBroker -fg -multiservice -ngsiv1Autocast -dbhost mongodb -logLevel DEBUG"
         image: "fiware/orion:2.2.0"
         imagePullPolicy: IfNotPresent
         name: orion

--- a/deployment/orion_service.yaml
+++ b/deployment/orion_service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: orion
 spec:
   ports:
-  - name: ngsi
+  - name: http
     port: 1026
     protocol: TCP
     targetPort: 1026
@@ -29,9 +29,6 @@ spec:
       app: orion
   template:
     metadata:
-      annotations:
-        "scheduler.alpha.kubernetes.io/critical-pod": ""
-        sidecar.istio.io/inject: "false"
       labels:
         app: orion
     spec:
@@ -50,4 +47,4 @@ spec:
         name: orion
         ports:
         - containerPort: 1026
-          name: ngsi
+          name: http

--- a/scripts/cluster-url.sh
+++ b/scripts/cluster-url.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
-export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+set -e
+
 export INGRESS_HOST=$(minikube ip)
+export INGRESS_PORT=$(kubectl -n istio-system \
+                      get service istio-ingressgateway \
+                      -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+
 export BASE_URL="http://${INGRESS_HOST}:${INGRESS_PORT}"
+
+export ORION_INGRESS_PORT=$(kubectl \
+    -n istio-system get service istio-ingressgateway \
+    -o jsonpath='{.spec.ports[?(@.name=="orion")].nodePort}')
+export ORION_BASE_URL="http://${INGRESS_HOST}:${ORION_INGRESS_PORT}"

--- a/scripts/orion.post-entity.sh
+++ b/scripts/orion.post-entity.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+if [[ -z "${HEADER_VALUE// }" ]];
+then
+    echo ">>> HEADER_VALUE env var not set properly"
+    echo ">>> set HEADER_VALUE as explained in README"
+    exit 1
+fi
+
+
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR="$(dirname "$SCRIPTPATH")"
+SCRIPTSDIR="${ROOTDIR}/scripts"
+
+source "${SCRIPTSDIR}/cluster-url.sh"
+
+
+curl -v "${ORION_BASE_URL}/v2/entities" \
+     -H "header: ${HEADER_VALUE}" -H 'Content-Type: application/json' \
+     -d @- <<EOF
+{
+  "id": "Room1",
+  "type": "Room",
+  "temperature": {
+    "value": 23,
+    "type": "Float"
+  },
+  "pressure": {
+    "value": 720,
+    "type": "Integer"
+  }
+}
+EOF

--- a/scripts/orion.sub.sh
+++ b/scripts/orion.sub.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+if [[ -z "${HEADER_VALUE// }" ]];
+then
+    echo ">>> HEADER_VALUE env var not set properly"
+    echo ">>> set HEADER_VALUE as explained in README"
+    exit 1
+fi
+
+
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR="$(dirname "$SCRIPTPATH")"
+SCRIPTSDIR="${ROOTDIR}/scripts"
+
+source "${SCRIPTSDIR}/cluster-url.sh"
+
+
+curl -v "${ORION_BASE_URL}/v2/subscriptions" \
+     -H "header: ${HEADER_VALUE}" -H 'Content-Type: application/json' \
+     -d @- <<EOF
+{
+  "description": "A subscription to get info about Room1",
+  "subject": {
+    "entities": [
+      {
+        "id": "Room1",
+        "type": "Room"
+      }
+    ],
+    "condition": {
+      "attrs": [
+        "pressure"
+      ]
+    }
+  },
+  "notification": {
+    "http": {
+      "url": "http://httpbin.org/post"
+    },
+    "attrs": [
+      "temperature"
+    ]
+  },
+  "expires": "2040-01-01T14:00:00.00Z",
+  "throttling": 5
+}
+EOF

--- a/scripts/orion.update-entity.sh
+++ b/scripts/orion.update-entity.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+if [[ -z "${HEADER_VALUE// }" ]];
+then
+    echo ">>> HEADER_VALUE env var not set properly"
+    echo ">>> set HEADER_VALUE as explained in README"
+    exit 1
+fi
+
+
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR="$(dirname "$SCRIPTPATH")"
+SCRIPTSDIR="${ROOTDIR}/scripts"
+
+source "${SCRIPTSDIR}/cluster-url.sh"
+
+
+curl -v "${ORION_BASE_URL}/v2/entities/Room1/attrs" \
+     -H "header: ${HEADER_VALUE}" -H 'Content-Type: application/json' \
+     -X PATCH -d @- <<EOF
+{
+  "temperature": {
+    "value": 21.5,
+    "type": "Float"
+  },
+  "pressure": {
+    "value": 703,
+    "type": "Float"
+  }
+}
+EOF

--- a/yamster/src/Mesh/Config/Services.hs
+++ b/yamster/src/Mesh/Config/Services.hs
@@ -81,15 +81,21 @@ orion = def
                       "-ngsiv1Autocast -dbhost " ++ serviceName mongodb ++
                       " -logLevel DEBUG"
   , ports           =
-    [ def { portName      = Just "ngsi"
+    [ def { portName      = Just "http"  -- (1)
           , servicePort   = 1026
-          , externalPort  = Just 1026  -- (*)
+          , externalPort  = Just 1026    -- (2)
           }
     ]
-  , withSideCar = False
+  , withSideCar = True
   }
 --
--- (*) NOTE. Custom external ports.
+-- NOTE
+-- (1) Port name. Surely `ngsi` would make more sense here, but if we
+-- set it to anything else than `http`, then the sidecar stops forwarding
+-- messages to Orion. Uh, WTH.
+-- See: https://github.com/orchestracities/boost/issues/28
+--
+-- (2) Custom external ports.
 -- The Istio demo profile exposes some common ports like 80 and 443
 -- through load-balancer cluster ports 30072 and 31515, respectively.
 -- We have to add our Orion port manually to the load balancer config:

--- a/yamster/src/Mesh/Config/Services.hs
+++ b/yamster/src/Mesh/Config/Services.hs
@@ -54,10 +54,10 @@ mockdaps = def
 -- WARNING. only use for testing as DB data isn't persisted!
 mongodb ∷ ServiceSpec
 mongodb = def
-  { serviceName     = "mongodb"
-  , image           = "mongo:3.6"
-  , command         = CmdStr "mongod --bind_ip_all --smallfiles"
-  , ports           = [ mongo { servicePort   = 27017 } ]
+  { serviceName = "mongodb"
+  , image       = "mongo:3.6"
+  , command     = CmdStr "mongod --bind_ip_all --smallfiles"
+  , ports       = [ mongo { servicePort = 27017 } ]
   , withSideCar = False
   }
 
@@ -86,7 +86,6 @@ orion = def
       , externalPort  = Just 1026  -- (2)
       }
     ]
-  , withSideCar = True
   }
 --
 -- NOTE

--- a/yamster/src/Mesh/Config/Services.hs
+++ b/yamster/src/Mesh/Config/Services.hs
@@ -13,23 +13,18 @@ httpbin = def
   , version     = Just "v1"
   , image       = "docker.io/kennethreitz/httpbin"
   , ports       =
-    [ def { portName      = Just "http"
-          , servicePort   = 8000
-          , containerPort = Just 80
-          , externalPort  = Just 80
-          }
+    [ http { servicePort   = 8000
+           , containerPort = Just 80
+           , externalPort  = Just 80
+           }
     ]
   }
 
 orionadapterHttpEndpoint ∷ Port
-orionadapterHttpEndpoint = def { portName    = Just "http"
-                               , servicePort = 54321
-                               }
+orionadapterHttpEndpoint = http { servicePort = 54321 }
 
 orionadapterGrpcEndpoint ∷ Port
-orionadapterGrpcEndpoint = def { portName    = Just "grpc"
-                               , servicePort = 43210
-                               }
+orionadapterGrpcEndpoint = grpc { servicePort = 43210 }
 
 orionadapter ∷ ServiceSpec
 orionadapter = def
@@ -44,9 +39,7 @@ orionadapter = def
   }
 
 mockdapsHttpsEndpoint ∷ Port
-mockdapsHttpsEndpoint = def { portName    = Just "https"
-                            , servicePort = 44300
-                            }
+mockdapsHttpsEndpoint = https { servicePort = 44300 }
 
 mockdaps ∷ ServiceSpec
 mockdaps = def
@@ -63,28 +56,35 @@ mongodb ∷ ServiceSpec
 mongodb = def
   { serviceName     = "mongodb"
   , image           = "mongo:3.6"
-  , command         = Just "mongod --bind_ip_all --smallfiles"
-  , ports           =
-    [ def { portName      = Just "mongo"
-          , servicePort   = 27017
-          }
-    ]
+  , command         = CmdStr "mongod --bind_ip_all --smallfiles"
+  , ports           = [ mongo { servicePort   = 27017 } ]
   , withSideCar = False
   }
+
+
+startOrion ∷ ContainerCommand
+startOrion = Cmd "bash" ["-c", script]
+  where
+    script =  "sleep 4; "  -- (*)
+           ++ "exec /usr/bin/contextBroker -fg -multiservice -ngsiv1Autocast "
+           ++ "-dbhost " ++ serviceName mongodb
+           ++ " -logLevel DEBUG"
+-- NOTE
+-- (*) Poor man's approach to start-up race conditions and service
+-- dependencies.
+-- See: https://github.com/orchestracities/boost/issues/28
+--
 
 orion ∷ ServiceSpec
 orion = def
   { serviceName     = "orion"
   , image           = "fiware/orion:2.2.0"
-  , command         = Just $
-                      "/usr/bin/contextBroker -fg -multiservice " ++
-                      "-ngsiv1Autocast -dbhost " ++ serviceName mongodb ++
-                      " -logLevel DEBUG"
+  , command         = startOrion
   , ports           =
-    [ def { portName      = Just "http"  -- (1)
-          , servicePort   = 1026
-          , externalPort  = Just 1026    -- (2)
-          }
+    [ http                         -- (1)
+      { servicePort   = 1026
+      , externalPort  = Just 1026  -- (2)
+      }
     ]
   , withSideCar = True
   }

--- a/yamster/src/Mesh/Config/Services.hs
+++ b/yamster/src/Mesh/Config/Services.hs
@@ -65,7 +65,7 @@ mongodb = def
 startOrion ∷ ContainerCommand
 startOrion = Cmd "bash" ["-c", script]
   where
-    script =  "sleep 4; "  -- (*)
+    script =  "sleep 10; "  -- (*)
            ++ "exec /usr/bin/contextBroker -fg -multiservice -ngsiv1Autocast "
            ++ "-dbhost " ++ serviceName mongodb
            ++ " -logLevel DEBUG"

--- a/yamster/src/Mesh/Make/Deploy.hs
+++ b/yamster/src/Mesh/Make/Deploy.hs
@@ -84,7 +84,7 @@ deploymentFiles repoRoot = do
   let YamlTargets{..} = yamlTargets b
   let writeS = writeServiceAndDeployment yamsterDir
   let writeR = writeRoutes yamsterDir
-  let writeE = writeExprs yamsterDir ∘ pure
+  let writeE = writeExprs yamsterDir
 
   want [ egress_filter
        , httpbin_service
@@ -96,7 +96,7 @@ deploymentFiles repoRoot = do
        , sample_operator_cfg
        ]
 
-  egress_filter         %> writeE orionEgressFilter
+  egress_filter         %> writeE [orionEgressFilter, httpbinEgressFilter]
   httpbin_service       %> writeS httpbin
   ingress_routing       %> writeR boostGateway
   mock_daps_service     %> writeS mockdaps

--- a/yamster/src/Mesh/Util/Istio.hs
+++ b/yamster/src/Mesh/Util/Istio.hs
@@ -3,9 +3,11 @@ module Mesh.Util.Istio
   ( module Mesh.Util.Istio.Adapter
   , module Mesh.Util.Istio.Ingress
   , module Mesh.Util.Istio.Namespace
+  , module Mesh.Util.Istio.Ports
   )
 where
 
 import Mesh.Util.Istio.Adapter
 import Mesh.Util.Istio.Ingress
 import Mesh.Util.Istio.Namespace
+import Mesh.Util.Istio.Ports

--- a/yamster/src/Mesh/Util/Istio/Ports.hs
+++ b/yamster/src/Mesh/Util/Istio/Ports.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE UnicodeSyntax #-}
+module Mesh.Util.Istio.Ports
+where
+
+import Data.Default (def)
+
+import Mesh.Util.K8s (Port (..))
+
+
+-- Istio uses K8s port names to select protocols! We capture that here
+-- to avoid costly config mistakes.
+-- See:
+-- https://archive.istio.io/v1.4/docs/ops/configuration/traffic-management/protocol-selection/
+-- https://github.com/orchestracities/boost/issues/28
+
+grpc ∷ Port
+grpc = def { portName = Just "grpc" }
+
+grcpweb ∷ Port
+grcpweb = def { portName = Just "grpc-web" }
+
+http ∷ Port
+http = def { portName = Just "http" }
+
+http2 ∷ Port
+http2 = def { portName = Just "http2" }
+
+https ∷ Port
+https = def { portName = Just "https" }
+
+mongo ∷ Port
+mongo = def { portName = Just "mongo" }
+
+mysql ∷ Port
+mysql = def { portName = Just "mysql" }
+
+redis ∷ Port
+redis = def { portName = Just "redis" }
+
+tcp ∷ Port
+tcp = def { portName = Just "tcp" }
+
+tls ∷ Port
+tls = def { portName = Just "tls" }
+
+udp ∷ Port
+udp = def { portName = Just "udp" }


### PR DESCRIPTION
This PR works out the issues we've been having with the Orion sidecar as documented by #28.
We can now run Orion as a mesh service with an Istio sidecar. Notice our (test) mesh configuration doesn't include any

1. Orion/MongoDB initialisation---DB indexes, etc.
2. Robust handling of start-up race conditions---see #28 about it.

(1) is quite hard to do with an Orion init container as we do in Orchestra since we've got the sidecar in between with its own init container. Doing it without an Orion init container is possible but then we'll have to deal with race conditions.

We've introduced a 10 second delay before starting Orion to make it less likely to get race conditions at start-up---yep, poor's man approach to concurrency. So we can't claim we've got a robust solution for that.

We should make (1) and (2) visible to mesh admins so that they can roll out their own solution, e.g. readiness/liveness probes to make Orion bounce back after a startup failure---see #28 about it.
